### PR TITLE
Eliminate NAG compiler warnings

### DIFF
--- a/src/julienne/julienne_file_s.f90
+++ b/src/julienne/julienne_file_s.f90
@@ -88,6 +88,8 @@ contains
         do line_num = 1, num_lines
           do
             read(file_unit, '(a)', advance='no', iostat=io_status, iomsg=error_message) c
+            associate(eliminate_nagfor_warning => c) ! eliminates "variable c set but never referenced" warning
+            end associate
             if (io_status==iostat_eor .or. io_status==iostat_end) exit
             lengths(line_num) = lengths(line_num) + 1
           end do

--- a/src/julienne/julienne_vector_test_description_m.f90
+++ b/src/julienne/julienne_vector_test_description_m.f90
@@ -4,7 +4,6 @@ module julienne_vector_test_description_m
   !! Define an abstraction for describing test intentions and array-valued test functions
   use julienne_string_m, only : string_t
   use julienne_test_result_m, only : test_result_t
-  use assert_m, only : assert
   implicit none
 
   private

--- a/src/julienne/julienne_vector_test_description_s.f90
+++ b/src/julienne/julienne_vector_test_description_s.f90
@@ -1,4 +1,5 @@
 submodule(julienne_vector_test_description_m) julienne_vector_test_description_s
+  use assert_m, only : assert
   implicit none
 
 contains


### PR DESCRIPTION
This PR eliminates two NAG compiler warnings discovered when julienne is concatenated into a single source file by the script [create-single-source-file-programs.sh](https://github.com/BerkeleyLab/inference-engine/blob/e48260f4572036a572663374565a97b13ecc54ca/scripts/create-single-source-file-programs.sh)