### PR TITLE
Trims and character keys

### DIFF
--- a/src/julienne/julienne_string_m.f90
+++ b/src/julienne/julienne_string_m.f90
@@ -23,8 +23,18 @@ module julienne_string_m
     generic :: operator(/=)   => string_t_ne_string_t, string_t_ne_character, character_ne_string_t
     generic :: operator(==)   => string_t_eq_string_t, string_t_eq_character, character_eq_string_t
     generic :: assignment(= ) => assign_string_t_to_character, assign_character_to_string_t
-    generic :: get_json_value => get_integer_array, get_logical, get_integer, get_string, get_real, get_real_array
-    procedure, private            :: get_integer_array, get_logical, get_integer, get_string, get_real, get_real_array
+    generic :: get_json_value => get_real, get_real_with_character_key & 
+                                ,get_string, get_string_with_character_key & 
+                                ,get_logical, get_logical_with_character_key  &
+                                ,get_real_array ,get_real_array_with_character_key &
+                                ,get_integer_array, get_integer_array_with_character_key &
+                                ,get_integer, get_integer_with_character_key
+    procedure, private :: get_real, get_real_with_character_key
+    procedure, private :: get_string, get_string_with_character_key
+    procedure, private :: get_logical, get_logical_with_character_key
+    procedure, private :: get_integer, get_integer_with_character_key
+    procedure, private :: get_real_array, get_real_array_with_character_key
+    procedure, private :: get_integer_array, get_integer_array_with_character_key
     procedure, private            :: string_t_ne_string_t, string_t_ne_character
     procedure, private            :: string_t_eq_string_t, string_t_eq_character
     procedure, private            :: assign_character_to_string_t
@@ -111,10 +121,33 @@ module julienne_string_m
       real value_
     end function
 
+    pure module function get_real_with_character_key(self, key, mold) result(value_)
+      implicit none
+      class(string_t), intent(in) :: self
+      character(len=*), intent(in) :: key
+      real, intent(in) :: mold
+      real value_
+    end function
+
+    elemental module function get_string_with_character_key(self, key, mold) result(value_)
+      implicit none
+      class(string_t), intent(in) :: self, mold
+      character(len=*), intent(in) :: key
+      type(string_t) :: value_
+    end function
+
     elemental module function get_string(self, key, mold) result(value_)
       implicit none
       class(string_t), intent(in) :: self, key, mold
       type(string_t) :: value_
+    end function
+
+    pure module function get_integer_with_character_key(self, key, mold) result(value_)
+      implicit none
+      class(string_t), intent(in) :: self
+      character(len=*), intent(in) :: key
+      integer, intent(in) ::  mold
+      integer value_
     end function
 
     pure module function get_integer(self, key, mold) result(value_)
@@ -124,6 +157,14 @@ module julienne_string_m
       integer value_
     end function
 
+    pure module function get_logical_with_character_key(self, key, mold) result(value_)
+      implicit none
+      class(string_t), intent(in) :: self
+      character(len=*), intent(in) :: key
+      logical, intent(in) :: mold
+      logical value_
+    end function
+
     elemental module function get_logical(self, key, mold) result(value_)
       implicit none
       class(string_t), intent(in) :: self, key
@@ -131,11 +172,27 @@ module julienne_string_m
       logical value_
     end function
 
+    pure module function get_integer_array_with_character_key(self, key, mold) result(value_)
+      implicit none
+      class(string_t), intent(in) :: self
+      character(len=*), intent(in) :: key
+      integer, intent(in) :: mold(:)
+      integer, allocatable :: value_(:)
+    end function
+
     pure module function get_integer_array(self, key, mold) result(value_)
       implicit none
       class(string_t), intent(in) :: self, key
       integer, intent(in) :: mold(:)
       integer, allocatable :: value_(:)
+    end function
+
+    pure module function get_real_array_with_character_key(self, key, mold) result(value_)
+      implicit none
+      class(string_t), intent(in) :: self
+      character(len=*), intent(in) :: key
+      real, intent(in) :: mold(:)
+      real, allocatable :: value_(:)
     end function
 
     pure module function get_real_array(self, key, mold) result(value_)

--- a/src/julienne/julienne_string_m.f90
+++ b/src/julienne/julienne_string_m.f90
@@ -23,10 +23,8 @@ module julienne_string_m
     generic :: operator(/=)   => string_t_ne_string_t, string_t_ne_character, character_ne_string_t
     generic :: operator(==)   => string_t_eq_string_t, string_t_eq_character, character_eq_string_t
     generic :: assignment(= ) => assign_string_t_to_character, assign_character_to_string_t
-    generic :: get_json_value =>     get_json_integer_array, get_json_logical, get_json_integer, get_json_string, get_json_real, &
-                                     get_json_real_array
-    procedure, private            :: get_json_integer_array, get_json_logical, get_json_integer, get_json_string, get_json_real, &
-                                     get_json_real_array
+    generic :: get_json_value => get_integer_array, get_logical, get_integer, get_string, get_real, get_real_array
+    procedure, private            :: get_integer_array, get_logical, get_integer, get_string, get_real, get_real_array
     procedure, private            :: string_t_ne_string_t, string_t_ne_character
     procedure, private            :: string_t_eq_string_t, string_t_eq_character
     procedure, private            :: assign_character_to_string_t
@@ -106,41 +104,41 @@ module julienne_string_m
       type(string_t) base
     end function
 
-    pure module function get_json_real(self, key, mold) result(value_)
+    pure module function get_real(self, key, mold) result(value_)
       implicit none
       class(string_t), intent(in) :: self, key
       real, intent(in) :: mold
       real value_
     end function
 
-    elemental module function get_json_string(self, key, mold) result(value_)
+    elemental module function get_string(self, key, mold) result(value_)
       implicit none
       class(string_t), intent(in) :: self, key, mold
       type(string_t) :: value_
     end function
 
-    pure module function get_json_integer(self, key, mold) result(value_)
+    pure module function get_integer(self, key, mold) result(value_)
       implicit none
       class(string_t), intent(in) :: self, key
       integer, intent(in) ::  mold
       integer value_
     end function
 
-    elemental module function get_json_logical(self, key, mold) result(value_)
+    elemental module function get_logical(self, key, mold) result(value_)
       implicit none
       class(string_t), intent(in) :: self, key
       logical, intent(in) :: mold
       logical value_
     end function
 
-    pure module function get_json_integer_array(self, key, mold) result(value_)
+    pure module function get_integer_array(self, key, mold) result(value_)
       implicit none
       class(string_t), intent(in) :: self, key
       integer, intent(in) :: mold(:)
       integer, allocatable :: value_(:)
     end function
 
-    pure module function get_json_real_array(self, key, mold) result(value_)
+    pure module function get_real_array(self, key, mold) result(value_)
       implicit none
       class(string_t), intent(in) :: self, key
       real, intent(in) :: mold(:)

--- a/src/julienne/julienne_string_s.f90
+++ b/src/julienne/julienne_string_s.f90
@@ -102,10 +102,10 @@ contains
     end associate
   end procedure
 
-  module procedure get_json_real
+  module procedure get_real
     character(len=:), allocatable :: raw_line, string_value
 
-    call assert(key==self%get_json_key(), "string_s(get_json_real): key==self%get_json_key()", key)
+    call assert(key==self%get_json_key(), "string_s(get_real): key==self%get_json_key()", key)
 
     raw_line = self%string()
     associate(text_after_colon => raw_line(index(raw_line, ':')+1:))
@@ -121,7 +121,7 @@ contains
 
   end procedure
 
-  module procedure get_json_string
+  module procedure get_string
 
     character(len=:), allocatable :: raw_line
 
@@ -142,10 +142,10 @@ contains
 
   end procedure
 
-  module procedure get_json_logical
+  module procedure get_logical
     character(len=:), allocatable :: raw_line, string_value
 
-    call assert(key==self%get_json_key(), "string_s(get_json_logical): key==self%get_json_key()", key)
+    call assert(key==self%get_json_key(), "string_s(get_logical): key==self%get_json_key()", key)
 
     raw_line = self%string()
     associate(text_after_colon => raw_line(index(raw_line, ':')+1:))
@@ -156,17 +156,17 @@ contains
           string_value = trim(adjustl((text_after_colon(:trailing_comma-1))))
         end if
         call assert(string_value=="true" .or. string_value=="false", &
-          'string_s(get_json_logical): string_value=="true" .or. string_value="false"', string_value)
+          'string_s(get_logical): string_value=="true" .or. string_value="false"', string_value)
         value_ = string_value == "true"
       end associate
     end associate
 
   end procedure
 
-  module procedure get_json_integer
+  module procedure get_integer
     character(len=:), allocatable :: raw_line, string_value
 
-    call assert(key==self%get_json_key(), "string_s(get_json_logical): key==self%get_json_key()", key)
+    call assert(key==self%get_json_key(), "string_s(get_logical): key==self%get_json_key()", key)
 
     raw_line = self%string()
     associate(text_after_colon => raw_line(index(raw_line, ':')+1:))
@@ -182,16 +182,16 @@ contains
 
   end procedure
 
-  module procedure get_json_integer_array
-    value_ = int(self%get_json_real_array(key,mold=[0.]))
+  module procedure get_integer_array
+    value_ = int(self%get_real_array(key,mold=[0.]))
   end procedure
 
-  module procedure get_json_real_array
+  module procedure get_real_array
     character(len=:), allocatable :: raw_line
     real, allocatable :: real_array(:)
     integer i
 
-    call assert(key==self%get_json_key(), "string_s(get_json_{real,integer}_array): key==self%get_json_key()", key)
+    call assert(key==self%get_json_key(), "string_s(get_{real,integer}_array): key==self%get_json_key()", key)
 
     raw_line = self%string()
     associate(colon => index(raw_line, ":"))

--- a/src/julienne/julienne_string_s.f90
+++ b/src/julienne/julienne_string_s.f90
@@ -102,6 +102,10 @@ contains
     end associate
   end procedure
 
+  module procedure get_real_with_character_key
+    value_ = self%get_real(string_t(key), mold)
+  end procedure
+
   module procedure get_real
     character(len=:), allocatable :: raw_line, string_value
 
@@ -119,6 +123,10 @@ contains
       end associate
     end associate
 
+  end procedure
+
+  module procedure get_string_with_character_key
+    value_ = self%get_string(string_t(key), mold)
   end procedure
 
   module procedure get_string
@@ -140,6 +148,10 @@ contains
       end associate
     end associate
 
+  end procedure
+
+  module procedure get_logical_with_character_key
+    value_ = self%get_logical(string_t(key), mold)
   end procedure
 
   module procedure get_logical
@@ -182,8 +194,20 @@ contains
 
   end procedure
 
+  module procedure get_integer_with_character_key
+    value_ = self%get_integer(string_t(key), mold)
+  end procedure
+
+  module procedure get_integer_array_with_character_key
+    value_ = int(self%get_integer_array(string_t(key), mold))
+  end procedure
+
   module procedure get_integer_array
     value_ = int(self%get_real_array(key,mold=[0.]))
+  end procedure
+
+  module procedure get_real_array_with_character_key
+    value_ = self%get_real_array(string_t(key), mold)
   end procedure
 
   module procedure get_real_array

--- a/src/julienne/julienne_string_s.f90
+++ b/src/julienne/julienne_string_s.f90
@@ -22,13 +22,13 @@ contains
     integer, parameter :: sign_width = 1, digits_width = range(i) + 1
     character(len = digits_width + sign_width) characters
     write(characters, '(i0)') i
-    string = string_t(characters)
+    string = string_t(trim(characters))
   end procedure
 
   module procedure from_real
     character(len=100) characters
     write(characters, '(g0)') x
-    string = string_t(characters)
+    string = string_t(trim(characters))
   end procedure
 
   module procedure concatenate_elements


### PR DESCRIPTION
This PR 
1. Trim the strings produced by `string_t` constructors that take intrinsic-type values as arguments,
2.  Support `character` keys in json-value getters.