### PR TITLE
Feature/Chore: new get_json_value getters / add copyrights 

### DIFF
--- a/example/check-command-line-argument.f90
+++ b/example/check-command-line-argument.f90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 program check_command_line_argument
   !! This program serves the dual purposes of 
   !! 1. Showing how to use the command_line_t derived type to check whether a

--- a/example/get-flag-value.f90
+++ b/example/get-flag-value.f90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 program get_flag_value
   !! Demonstrate how to find the value of a command-line flag 
   !! Running this program as follows with the command

--- a/example/handle-missing-flag.f90
+++ b/example/handle-missing-flag.f90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 program handle_missing_flag
   !! This program serves the dual purposes of
   !!

--- a/src/julienne/julienne_string_m.f90
+++ b/src/julienne/julienne_string_m.f90
@@ -23,22 +23,24 @@ module julienne_string_m
     generic :: operator(/=)   => string_t_ne_string_t, string_t_ne_character, character_ne_string_t
     generic :: operator(==)   => string_t_eq_string_t, string_t_eq_character, character_eq_string_t
     generic :: assignment(= ) => assign_string_t_to_character, assign_character_to_string_t
-    generic :: get_json_value => get_real, get_real_with_character_key & 
-                                ,get_string, get_string_with_character_key & 
+    generic :: get_json_value => get_real, get_real_with_character_key &
+                                ,get_string &
+                                ,get_character, get_character_with_character_key &
                                 ,get_logical, get_logical_with_character_key  &
                                 ,get_real_array ,get_real_array_with_character_key &
                                 ,get_integer_array, get_integer_array_with_character_key &
                                 ,get_integer, get_integer_with_character_key
     procedure, private :: get_real, get_real_with_character_key
-    procedure, private :: get_string, get_string_with_character_key
+    procedure, private :: get_string
     procedure, private :: get_logical, get_logical_with_character_key
     procedure, private :: get_integer, get_integer_with_character_key
     procedure, private :: get_real_array, get_real_array_with_character_key
     procedure, private :: get_integer_array, get_integer_array_with_character_key
-    procedure, private            :: string_t_ne_string_t, string_t_ne_character
-    procedure, private            :: string_t_eq_string_t, string_t_eq_character
-    procedure, private            :: assign_character_to_string_t
-    procedure, private            :: string_t_cat_string_t, string_t_cat_character
+    procedure, private :: get_character, get_character_with_character_key
+    procedure, private :: string_t_ne_string_t, string_t_ne_character
+    procedure, private :: string_t_eq_string_t, string_t_eq_character
+    procedure, private :: assign_character_to_string_t
+    procedure, private :: string_t_cat_string_t, string_t_cat_character
     procedure, private, pass(rhs) :: character_cat_string_t
     procedure, private, pass(rhs) :: character_ne_string_t
     procedure, private, pass(rhs) :: character_eq_string_t
@@ -129,11 +131,18 @@ module julienne_string_m
       real value_
     end function
 
-    elemental module function get_string_with_character_key(self, key, mold) result(value_)
+    pure module function get_character(self, key, mold) result(value_)
       implicit none
-      class(string_t), intent(in) :: self, mold
-      character(len=*), intent(in) :: key
-      type(string_t) :: value_
+      class(string_t), intent(in) :: self, key
+      character(len=*), intent(in) :: mold
+      character(len=:), allocatable :: value_
+    end function
+
+    pure module function get_character_with_character_key(self, key, mold) result(value_)
+      implicit none
+      class(string_t), intent(in) :: self
+      character(len=*), intent(in) :: key, mold
+      character(len=:), allocatable :: value_
     end function
 
     elemental module function get_string(self, key, mold) result(value_)

--- a/src/julienne/julienne_string_s.f90
+++ b/src/julienne/julienne_string_s.f90
@@ -125,8 +125,16 @@ contains
 
   end procedure
 
-  module procedure get_string_with_character_key
-    value_ = self%get_string(string_t(key), mold)
+  module procedure get_character
+    associate(string_value => self%get_string(key, string_t(mold)))
+      value_ = string_value%string()
+    end associate
+  end procedure
+
+  module procedure get_character_with_character_key
+    associate(string_value => self%get_string(string_t(key), string_t(mold)))
+      value_ = string_value%string()
+    end associate
   end procedure
 
   module procedure get_string

--- a/test/bin_test.F90
+++ b/test/bin_test.F90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 module bin_test_m
   !! Check data partitioning across bins
   use julienne_m, only : bin_t, test_t, test_result_t, test_description_t, test_description_substring, string_t

--- a/test/command_line_test.F90
+++ b/test/command_line_test.F90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 module command_line_test_m
   !! Verify object pattern asbtract parent
   use julienne_m, only : test_t, test_result_t, command_line_t, test_description_substring, string_t, test_description_t

--- a/test/formats_test.F90
+++ b/test/formats_test.F90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 module formats_test_m
   !! Verify that format strings provide the desired formatting
   use julienne_m, only : separated_values, test_t, test_result_t, test_description_t, test_description_substring, string_t

--- a/test/main.F90
+++ b/test/main.F90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 program main
   use bin_test_m, only : bin_test_t
   use command_line_test_m, only : command_line_test_t

--- a/test/string_test.F90
+++ b/test/string_test.F90
@@ -54,6 +54,8 @@ contains
       test_description_t &
         (string_t("extracting a string value from a colon-separated key/value pair"), extracts_string_value), &
       test_description_t &
+        (string_t("extracting a string value from a colon-separated key/value pair"), extracts_character_value), &
+      test_description_t &
         (string_t("extracting a logical value from a colon-separated key/value pair"), extracts_logical_value), &
       test_description_t &
         (string_t("extracting an integer array value from a colon-separated key/value pair"), extracts_integer_array_value), &
@@ -72,7 +74,7 @@ contains
       check_allocation_ptr, supports_equivalence_ptr, supports_non_equivalence_ptr, supports_concatenation_ptr, &
       assigns_string_ptr, assigns_character_ptr, constructs_from_integer_ptr, constructs_from_real_ptr, concatenates_ptr, &
       extracts_key_ptr, extracts_real_ptr, extracts_string_ptr, extracts_logical_ptr, extracts_integer_array_ptr, &
-      extracts_real_array_ptr, extracts_integer_ptr, extracts_file_base_ptr, extracts_file_name_ptr
+      extracts_real_array_ptr, extracts_integer_ptr, extracts_file_base_ptr, extracts_file_name_ptr, extracts_character_ptr
 
     check_allocation_ptr => check_allocation
     supports_equivalence_ptr => supports_equivalence_operator
@@ -86,6 +88,7 @@ contains
     extracts_key_ptr => extracts_key
     extracts_real_ptr => extracts_real_value
     extracts_string_ptr => extracts_string_value
+    extracts_character_ptr => extracts_character_value
     extracts_logical_ptr => extracts_logical_value
     extracts_integer_array_ptr  => extracts_integer_array_value
     extracts_real_array_ptr => extracts_real_array_value
@@ -109,6 +112,7 @@ contains
       test_description_t(string_t("extracting a key string from a colon-separated key/value pair"), extracts_key_ptr), &
       test_description_t(string_t("extracting a real value from a colon-separated key/value pair"), extracts_real_ptr), &
       test_description_t(string_t("extracting a string value from a colon-separated key/value pair"), extracts_string_ptr), &
+      test_description_t(string_t("extracting a character value from a colon-separated key/value pair"), extracts_character_ptr), &
       test_description_t(string_t("extracting a logical value from a colon-separated key/value pair"), extracts_logical_ptr), &
       test_description_t( &
         string_t("extracting an integer array value from a colon-separated key/value pair"), extracts_integer_array_ptr), &
@@ -163,6 +167,29 @@ contains
       type(string_t) line
       line = string_t('"pi" : 3.14159')
       passed = line%get_json_value(key=string_t("pi"), mold=1.) == 3.14159
+    end block
+#endif
+  end function
+
+  function extracts_character_value() result(passed)
+    logical passed
+
+#ifndef _CRAYFTN
+    associate(line => string_t('"foo" : "bar"'), line_with_comma => string_t('"foo" : "bar",'))
+      passed = line%get_json_value(key=string_t("foo"), mold="") == "bar" .and. &
+               line%get_json_value(key="foo" , mold="") == "bar" .and. &
+               line_with_comma%get_json_value(key=string_t("foo"), mold="") == "bar" .and. &
+               line_with_comma%get_json_value(key="foo" , mold="") == "bar"
+    end associate
+#else
+    block
+      type(string_t) line, line_with_comma
+      line = string_t('"foo" : "bar"')
+      line_with_comma = string_t('"foo" : "bar",')
+      passed = line%get_json_value(key=string_t("foo"), mold="") == "bar" .and. &
+               line%get_json_value(key="foo" , mold="") == "bar" .and. &
+               line_with_comma%get_json_value(key=string_t("foo"), mold="") == "bar" .and. &
+               line_with_comma%get_json_value(key="foo" , mold="") == "bar"
     end block
 #endif
   end function

--- a/test/string_test.F90
+++ b/test/string_test.F90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 module string_test_m
   use julienne_m, only : test_t, test_result_t, string_t, operator(.cat.), test_description_t, test_description_substring
 #ifdef __GFORTRAN__

--- a/test/test_description_test.F90
+++ b/test/test_description_test.F90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 module test_description_test_m
   !! Verify test_description_t object behavior
   use julienne_m, only : string_t, test_result_t, test_description_t, test_t, test_description_substring

--- a/test/test_result_test.F90
+++ b/test/test_result_test.F90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 module test_result_test_m
   !! Verify test_result_t object behavior
   use julienne_m, only : string_t, test_result_t, test_description_t, test_t, test_description_substring

--- a/test/vector_test_description_test.f90
+++ b/test/vector_test_description_test.f90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 module vector_test_description_test_m
   !! Verify vector_test_description_t object behavior
   use julienne_m, only : &


### PR DESCRIPTION
This PR
1. Adds three private `string_t` type-bound procedures supporting the public generic binding `get_json_value`:
   - `get_character`
   - `get_character_with_character_key`
   -  `get_string_with_character_key`
 2. Adds missing copyright headers to all files in two subdirectories:
    - `example/` and
    - `test/`.