### PR TITLE
Use language-feature macros and work around flang I/O issue

### DIFF
--- a/include/language-support.F90
+++ b/include/language-support.F90
@@ -1,0 +1,33 @@
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
+
+#ifndef HAVE_SELECTED_LOGICAL_KIND
+  ! Define whether the compiler supports standard intrinsic function selected_logical_kind(),
+  ! a feature introduced in Fortran 2023 clause 16.9.182.
+#if defined(_CRAYFTN) || defined(NAGFOR) || defined(__flang__)
+#define HAVE_SELECTED_LOGICAL_KIND 1
+#else
+#define HAVE_SELECTED_LOGICAL_KIND 0
+#endif
+#endif
+
+#ifndef HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
+  ! Define whether the compiler supports associating a procedure pointer dummy argument with an
+  ! actual argument that is a valid target for the pointer dummy in a procedure assignment, a
+  ! feature introduced in Fortran 2008 and described in Fortran 2023 clause 15.5.2.10 paragraph 5.
+#if defined(_CRAYFTN) || defined(__INTEL_COMPILER) || defined(NAGFOR) || defined(__flang__)
+#define HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY 1
+#else
+#define HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY 0
+#endif
+#endif
+
+#ifndef HAVE_MULTI_IMAGE_SUPPORT
+  ! Define whether the compiler supports the statements and intrinsic procedures that support
+  ! multi-image execution, e.g., this_image(), sync all, etc.
+#if defined(_CRAYFTN) || defined(__INTEL_COMPILER) || defined(NAGFOR) || defined(__GFORTRAN__)
+#define HAVE_MULTI_IMAGE_SUPPORT 1
+#else
+#define HAVE_MULTI_IMAGE_SUPPORT 0
+#endif
+#endif

--- a/src/julienne/julienne_test_result_s.f90
+++ b/src/julienne/julienne_test_result_s.f90
@@ -4,10 +4,6 @@ submodule(julienne_test_result_m) julienne_test_result_s
   use julienne_user_defined_collectives_m, only : co_all
   implicit none
 
-#ifdef __flang__
-  #define NO_MULTI_IMAGE_SUPPORT
-#endif
-
 contains
 
     module procedure construct_from_character
@@ -26,9 +22,7 @@ contains
 
     module procedure passed
       test_passed = self%passed_
-#ifndef NO_MULTI_IMAGE_SUPPORT
       call co_all(test_passed)
-#endif
     end procedure
 
     module procedure description_contains

--- a/src/julienne/julienne_test_s.F90
+++ b/src/julienne/julienne_test_s.F90
@@ -28,11 +28,12 @@ contains
             type(command_line_t) command_line
             test_description_substring = command_line%flag_value("--contains")
           end block
+          print *
           if (len(test_description_substring)==0) then
-            print*,"Running all tests."
-            print*,"(Add '-- --contains <string>' to run only tests with subjects or descriptions containing the specified string.)"
+            print '(a)',"Running all tests."
+            print '(a)',"(Add '-- --contains <string>' to run only tests with subjects or descriptions containing the specified string.)"
           else
-            print *,"Running only tests with subjects or descriptions containing '", test_description_substring,"'."
+            print '(*(a))',"Running only tests with subjects or descriptions containing '", test_description_substring,"'."
           end if
         end if first_report
 
@@ -52,7 +53,7 @@ contains
             block
               integer i
               do i=1,num_tests
-                if (me==1) print *,"   ",test_results(i)%characterize()
+                if (me==1) print '(3x,a)', test_results(i)%characterize()
               end do
             end block
           end if
@@ -83,7 +84,7 @@ contains
           tests = tests + num_tests
           if (me==1) then
             do i=1,num_tests
-              if (me==1) print *,"   ",test_results(i)%characterize()
+              if (me==1) print '(3x,a)', test_results(i)%characterize()
             end do
           end if
           passing_tests = test_results%passed()

--- a/src/julienne/julienne_user_defined_collectives_s.F90
+++ b/src/julienne/julienne_user_defined_collectives_s.F90
@@ -4,16 +4,13 @@
 !     "Multi-Dimensional Physics Implementation into Fuel Analysis under Steady-state and Transients (FAST)",
 !     contract # NRC-HQ-60-17-C-0007
 !
-#ifdef __flang__
-  #define NO_MULTI_IMAGE_SUPPORT
-#endif
 submodule(julienne_user_defined_collectives_m) julienne_user_defined_collectives_s
   implicit none
 
 contains
 
   module procedure co_all
-#ifndef NO_MULTI_IMAGE_SUPPORT
+#if HAVE_MULTI_IMAGE_SUPPORT
     call co_reduce(boolean, both)
 #endif
   contains

--- a/test/bin_test.F90
+++ b/test/bin_test.F90
@@ -1,9 +1,12 @@
 ! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
 ! Terms of use are as specified in LICENSE.txt
+
+#include "language-support.F90"
+
 module bin_test_m
   !! Check data partitioning across bins
   use julienne_m, only : bin_t, test_t, test_result_t, test_description_t, test_description_substring, string_t
-#ifdef __GFORTRAN__
+#if ! HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
   use julienne_m, only : test_function_i
 #endif
   use assert_m, only : assert
@@ -29,7 +32,7 @@ contains
     type(test_result_t), allocatable :: test_results(:)
     type(test_description_t), allocatable :: test_descriptions(:)
 
-#ifndef __GFORTRAN__
+#if HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
     test_descriptions = [ & 
       test_description_t(string_t("partitioning items nearly evenly across bins"), check_block_partitioning), &
       test_description_t(string_t("partitioning all item across all bins without item loss"), check_all_items_partitioned) &

--- a/test/command_line_test.F90
+++ b/test/command_line_test.F90
@@ -1,9 +1,12 @@
 ! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
 ! Terms of use are as specified in LICENSE.txt
+
+#include "language-support.F90"
+
 module command_line_test_m
   !! Verify object pattern asbtract parent
   use julienne_m, only : test_t, test_result_t, command_line_t, test_description_substring, string_t, test_description_t
-#ifdef __GFORTRAN__
+#if ! HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
   use julienne_m, only : test_function_i
 #endif
     
@@ -28,7 +31,7 @@ contains
   function results() result(test_results)
     type(test_result_t), allocatable :: test_results(:)
     type(test_description_t), allocatable :: test_descriptions(:)
-#ifndef __GFORTRAN__
+#if HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
     test_descriptions = [ & 
       test_description_t(string_t("returning the value passed after a command-line flag"), check_flag_value), &
       test_description_t(string_t("returning an empty string when a flag value is missing"), handle_missing_flag_value), &

--- a/test/formats_test.F90
+++ b/test/formats_test.F90
@@ -1,9 +1,12 @@
 ! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
 ! Terms of use are as specified in LICENSE.txt
+
+#include "language-support.F90"
+
 module formats_test_m
   !! Verify that format strings provide the desired formatting
   use julienne_m, only : separated_values, test_t, test_result_t, test_description_t, test_description_substring, string_t
-#ifdef __GFORTRAN__
+#if ! HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
   use julienne_m, only : test_function_i
 #endif
     
@@ -29,7 +32,7 @@ contains
     type(test_result_t), allocatable :: test_results(:)
     type(test_description_t), allocatable :: test_descriptions(:)
 
-#ifndef __GFORTRAN__
+#if HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
     test_descriptions = [ & 
       test_description_t(string_t("yielding a comma-separated list of real numbers"), check_csv_reals), &
       test_description_t(string_t("yielding a comma-separated list of double-precision numbers"), check_csv_double_precision), &

--- a/test/main.F90
+++ b/test/main.F90
@@ -54,7 +54,7 @@ program main
 #endif
 
     print *
-    print '(*(a,:,i))', "_________ In total, ",passes," of ",tests, " tests pass. _________"
+    print '(*(a,:,g0))', "_________ In total, ",passes," of ",tests, " tests pass. _________"
 
     if (passes /= tests) error stop "Some tests failed."
 

--- a/test/main.F90
+++ b/test/main.F90
@@ -54,7 +54,8 @@ program main
 #ifndef NO_MULTI_IMAGE_SUPPORT
   if (this_image()==1) &
 #endif
-  print *, new_line('a'), "_________ In total, ",passes," of ",tests, " tests pass. _________"
+  print *
+  print '(*(a,:,i))', "_________ In total, ",passes," of ",tests, " tests pass. _________"
   if (passes /= tests) error stop
 
 end program

--- a/test/main.F90
+++ b/test/main.F90
@@ -1,9 +1,7 @@
 ! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
 ! Terms of use are as specified in LICENSE.txt
 
-#if defined(__flang__)
-  #define NO_MULTI_IMAGE_SUPPORT
-#endif
+#include "language-support.F90"
 
 program main
   !! Julienne unit tests driver
@@ -51,11 +49,17 @@ program main
   call vector_test_description_test%report(passes,tests)
   if (.not. GitHub_CI())  call command_line_test%report(passes, tests)
 
-#ifndef NO_MULTI_IMAGE_SUPPORT
-  if (this_image()==1) &
+#if HAVE_MULTI_IMAGE_SUPPORT
+  if (this_image()==1) then
 #endif
-  print *
-  print '(*(a,:,i))', "_________ In total, ",passes," of ",tests, " tests pass. _________"
-  if (passes /= tests) error stop
+
+    print *
+    print '(*(a,:,i))', "_________ In total, ",passes," of ",tests, " tests pass. _________"
+
+    if (passes /= tests) error stop "Some tests failed."
+
+#if HAVE_MULTI_IMAGE_SUPPORT
+  end if
+#endif
 
 end program

--- a/test/string_test.F90
+++ b/test/string_test.F90
@@ -1,8 +1,11 @@
 ! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
 ! Terms of use are as specified in LICENSE.txt
+
+#include "language-support.F90"
+
 module string_test_m
   use julienne_m, only : test_t, test_result_t, string_t, operator(.cat.), test_description_t, test_description_substring
-#ifdef __GFORTRAN__
+#if ! HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
   use julienne_m, only : test_function_i
 #endif
   implicit none
@@ -27,7 +30,7 @@ contains
     type(test_result_t), allocatable :: test_results(:)
     type(test_description_t), allocatable :: test_descriptions(:)
 
-#ifndef __GFORTRAN__
+#if HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
     test_descriptions = [ & 
       test_description_t &
         (string_t("is_allocated() result .true. if & only if the string_t component(s) is/are allocated"), check_allocation), &

--- a/test/test_description_test.F90
+++ b/test/test_description_test.F90
@@ -1,9 +1,12 @@
 ! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
 ! Terms of use are as specified in LICENSE.txt
+
+#include "language-support.F90"
+
 module test_description_test_m
   !! Verify test_description_t object behavior
   use julienne_m, only : string_t, test_result_t, test_description_t, test_t, test_description_substring
-#ifdef __GFORTRAN__
+#if ! HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
   use julienne_m, only : test_function_i
 #endif
   implicit none
@@ -28,7 +31,7 @@ contains
     type(test_result_t), allocatable :: test_results(:)
     type(test_description_t), allocatable :: test_descriptions(:)
 
-#ifndef __GFORTRAN__
+#if HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
     test_descriptions = [ &
       test_description_t("identical construction from string_t or character arguments", check_character_constructor) &
     ]
@@ -51,7 +54,7 @@ contains
 
   function check_character_constructor() result(passed)
     logical passed
-#ifndef __GFORTRAN__
+#if HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
     passed = test_description_t("foo", tautology) == test_description_t(string_t("foo"), tautology)
 #else
     procedure(test_function_i), pointer :: test_function_ptr

--- a/test/test_result_test.F90
+++ b/test/test_result_test.F90
@@ -1,9 +1,12 @@
 ! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
 ! Terms of use are as specified in LICENSE.txt
+
+#include "language-support.F90" 
+
 module test_result_test_m
   !! Verify test_result_t object behavior
   use julienne_m, only : string_t, test_result_t, test_description_t, test_t, test_description_substring
-#ifdef __GFORTRAN__
+#if ! HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
   use julienne_m, only : test_function_i
 #endif
   implicit none
@@ -28,7 +31,7 @@ contains
     type(test_result_t), allocatable :: test_results(:)
     type(test_description_t), allocatable :: test_descriptions(:)
 
-#ifndef __GFORTRAN__
+#if HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
     test_descriptions = [ &
       test_description_t(string_t("constructing an array of test_result_t objects elementally"), check_array_result_construction), &
       test_description_t(string_t("reporting failure if the test fails on one image"), check_single_image_failure) &
@@ -61,11 +64,13 @@ contains
     type(test_result_t), allocatable :: test_result
     logical passed
 
-#ifndef __flang__
+#if HAVE_MULTI_IMAGE_SUPPORT
     if (this_image()==1) then
 #endif
+
       test_result = test_result_t("image 1 fails", .false.)
-#ifndef __flang__
+
+#if HAVE_MULTI_IMAGE_SUPPORT
     else
       test_result = test_result_t("all images other than 1 pass", .true.)
     end if


### PR DESCRIPTION
This PR
1. Replaces most compiler-specific macros with the language-feature macros defined in the new file `include/language-support.F90`,
2. Works around LLVM `flang-new` [issue 109589] that was erroneously wrapping list-directed output.

 [issue 109589]: https://github.com/llvm/llvm-project/issues/109589.