### PR TITLE
Features: string bracketing, CSV operators, and JSON array value reader

### DIFF
--- a/src/julienne/julienne_bin_m.f90
+++ b/src/julienne/julienne_bin_m.f90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 module julienne_bin_m
   !! distribute item numbers across bins such that the number of items differs by at most 1 between any two bins
   implicit none

--- a/src/julienne/julienne_bin_s.f90
+++ b/src/julienne/julienne_bin_s.f90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 submodule(julienne_bin_m) julienne_bin_s
   use assert_m, only : assert, intrinsic_array_t
   implicit none

--- a/src/julienne/julienne_file_m.f90
+++ b/src/julienne/julienne_file_m.f90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 module julienne_file_m
   !! A representation of a file as an object
   use julienne_string_m, only : string_t

--- a/src/julienne/julienne_file_s.f90
+++ b/src/julienne/julienne_file_s.f90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 submodule(julienne_file_m) julienne_file_s
   use iso_fortran_env, only : iostat_end, iostat_eor, output_unit
   use assert_m, only : assert

--- a/src/julienne/julienne_string_m.f90
+++ b/src/julienne/julienne_string_m.f90
@@ -7,7 +7,9 @@ module julienne_string_m
   private
   public :: string_t
   public :: array_of_strings
-  public :: operator(.cat.) ! element-wise concatenation operator
+  public :: operator(.cat.) ! element-wise concatenation unary operator
+  public :: operator(.csv.) ! comma-separated values unary operator
+  public :: operator(.sv.)  ! separated-values binary operator
 
   type, extends(characterizable_t) :: string_t
     private
@@ -84,7 +86,54 @@ module julienne_string_m
 
   end interface
 
+  interface operator(.csv.)
+
+    pure module function strings_with_comma_separator(strings) result(csv)
+      implicit none
+      type(string_t), intent(in) :: strings(:)
+      type(string_t) csv
+    end function
+
+    pure module function characters_with_comma_separator(strings) result(csv)
+      implicit none
+      character(len=*), intent(in) :: strings(:)
+      type(string_t) csv
+    end function
+
+  end interface
+
+  interface operator(.sv.)
+
+    pure module function strings_with_character_separator(strings, separator) result(sv)
+      implicit none
+      type(string_t)  , intent(in) :: strings(:)
+      character(len=*), intent(in) :: separator
+      type(string_t) sv
+    end function
+
+    pure module function characters_with_character_separator(strings, separator) result(sv)
+      implicit none
+      character(len=*), intent(in) :: strings(:), separator
+      type(string_t) sv
+    end function
+
+    pure module function characters_with_string_separator(strings, separator) result(sv)
+      implicit none
+      character(len=*), intent(in) :: strings(:)
+      type(string_t)  , intent(in) :: separator
+      type(string_t) sv
+    end function
+
+    pure module function strings_with_string_t_separator(strings, separator) result(sv)
+      implicit none
+      type(string_t), intent(in) :: strings(:), separator
+      type(string_t) sv 
+    end function
+
+  end interface
+
   interface
+
     pure module function as_character(self) result(raw_string)
       implicit none
       class(string_t), intent(in) :: self

--- a/src/julienne/julienne_string_m.f90
+++ b/src/julienne/julienne_string_m.f90
@@ -19,6 +19,7 @@ module julienne_string_m
     procedure :: get_json_key
     procedure :: file_extension
     procedure :: base_name
+    procedure :: bracket
     generic :: operator(//)   => string_t_cat_string_t, string_t_cat_character, character_cat_string_t
     generic :: operator(/=)   => string_t_ne_string_t, string_t_ne_character, character_ne_string_t
     generic :: operator(==)   => string_t_eq_string_t, string_t_eq_character, character_eq_string_t
@@ -323,6 +324,13 @@ module julienne_string_m
       class(string_t), intent(in) :: rhs
       character(len=:), intent(out), allocatable :: lhs
     end subroutine
+
+    elemental module function bracket(self, opening, closing) result(bracketed_self)
+      implicit none
+      class(string_t), intent(in) :: self
+      character(len=*), intent(in), optional :: opening, closing
+      type(string_t) bracketed_self
+    end function
 
   end interface
   

--- a/src/julienne/julienne_string_s.f90
+++ b/src/julienne/julienne_string_s.f90
@@ -40,6 +40,44 @@ contains
     end do
   end procedure
 
+  module procedure strings_with_comma_separator
+    csv = strings_with_string_t_separator(strings, string_t(","))
+  end procedure 
+
+  module procedure characters_with_comma_separator
+    csv = strings_with_string_t_separator(string_t(strings), string_t(","))
+  end procedure 
+
+  module procedure characters_with_character_separator
+    sv = strings_with_string_t_separator(string_t(strings), string_t(separator))
+  end procedure 
+
+  module procedure characters_with_string_separator
+    sv = strings_with_string_t_separator(string_t(strings), separator)
+  end procedure 
+
+  module procedure strings_with_character_separator
+    sv = strings_with_string_t_separator(strings, string_t(separator))
+  end procedure 
+
+  module procedure strings_with_string_t_separator
+
+    integer s 
+
+    associate(num_elements => size(strings))
+
+      sv = ""
+
+      do s = 1, num_elements - 1
+        sv = sv // strings(s) // separator
+      end do
+
+      sv = sv // strings(num_elements)
+
+    end associate
+
+  end procedure
+
   module procedure array_of_strings
     character(len=:), allocatable :: remainder, next_string
     integer next_delimiter, string_end

--- a/src/julienne/julienne_string_s.f90
+++ b/src/julienne/julienne_string_s.f90
@@ -366,4 +366,30 @@ contains
     lhs_cat_rhs = string_t(lhs // rhs%string_)
   end procedure
    
+  module procedure bracket
+  
+    character(len=:), allocatable :: actual_opening, actual_closing
+
+    associate(opening_present => present(opening))
+
+      if (opening_present) then
+        actual_opening = opening
+      else
+        actual_opening = "["
+      end if
+
+      if (present(closing)) then
+        actual_closing = closing
+      else if(opening_present) then
+        actual_closing = actual_opening
+      else
+        actual_closing = "]"
+      end if
+
+    end associate
+
+    bracketed_self = string_t(actual_opening // self%string_ // actual_closing)
+
+  end procedure
+   
 end submodule julienne_string_s

--- a/src/julienne/julienne_vector_test_description_s.f90
+++ b/src/julienne/julienne_vector_test_description_s.f90
@@ -1,3 +1,5 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
 submodule(julienne_vector_test_description_m) julienne_vector_test_description_s
   use assert_m, only : assert
   implicit none

--- a/src/julienne_m.f90
+++ b/src/julienne_m.f90
@@ -12,22 +12,5 @@ module julienne_m
   use julienne_test_description_m, only : test_description_t, test_function_i
   use julienne_test_result_m, only : test_result_t
   use julienne_vector_test_description_m, only : vector_test_description_t, vector_function_strategy_t
-
   implicit none
-  private
-  public :: bin_t
-  public :: csv
-  public :: command_line_t
-  public :: operator(.cat.)
-  public :: file_t
-  public :: github_ci
-  public :: separated_values
-  public :: string_t
-  public :: test_t
-  public :: test_description_t
-  public :: test_description_substring
-  public :: test_function_i
-  public :: test_result_t
-  public :: vector_function_strategy_t
-  public :: vector_test_description_t
 end module julienne_m

--- a/src/julienne_m.f90
+++ b/src/julienne_m.f90
@@ -7,7 +7,7 @@ module julienne_m
   use julienne_file_m, only : file_t
   use julienne_github_ci_m, only : github_ci
   use julienne_formats_m, only : separated_values, csv
-  use julienne_string_m, only : string_t, operator(.cat.)
+  use julienne_string_m, only : string_t, operator(.cat.), operator(.csv.), operator(.sv.)
   use julienne_test_m, only : test_t, test_description_substring
   use julienne_test_description_m, only : test_description_t, test_function_i
   use julienne_test_result_m, only : test_result_t


### PR DESCRIPTION
This PR adds 
    
1. A unary `operator(.csv.)` with a `string_t` result encapsulating a comma-separated value (CSV) created from
  a. a `string_t` array or
  b. a `character` array,
2. A binary `operator(.sv.)` with a `string_t` result encapsulating a CSV created from left- and right-hand operands:
  a. a `string_t` array and a `string_t` separator or
  b. a `string_t` array and a `character` separator.
  c. a `character` array and a `character` separator
  d. a `character` array and a `string_t` separator
3. A unit test that verifies the following identities:
```
"a,bc,def" == .csv. [string_t("a"), string_t("bc"), string_t("def")]
"abc,def"  == .csv. ["abc", "def"]
    
"do|re|mi" == (string_t(["do", "re", "mi"])         .sv.          "|" )
"dore|mi"  == (([string_t("dore"), string_t("mi")]) .sv. string_t("|"))
"do|re|mi" == (         ["do", "re", "mi"]          .sv.          "|" )
"do|re|mi" == (         ["do", "re", "mi"]          .sv. string_t("|"))
``` 
4. A `bracket` type-bound procedure and a test verifying the following identities:
```
scalar%bracket()           == string_t("[do re mi]") &
all(array%bracket()        == [string_t("[do]"), string_t("[re]"), string_t("[mi]")]) &
all(array%bracket('"')     == [string_t('"do"'), string_t('"re"'), string_t('"mi"')]) &
all(array%bracket("{","}") == [string_t('{do}'), string_t('{re}'), string_t('{mi}')]) &
```
5. A `get_string_t_array` specific procedure supporting the generic `get_json_value` binding and test verifying the following identities:
```
associate(json_line  => string_t('"lead singer" : ["stevie", "ray", "vaughn"],'))
  all( json_line%get_json_value(key=string_t("lead singer"), mold=[string_t::]) == [string_t("stevie"), string_t("ray"), string_t("vaughn")]))
end associate
```