### PR TITLE
fix(test_t): prevent subject wrapping in report

### DIFF
--- a/src/julienne/julienne_test_s.F90
+++ b/src/julienne/julienne_test_s.F90
@@ -35,7 +35,7 @@ contains
           end if
         end if first_report
 
-        print *, new_line('a'), test%subject()
+        print '(*(a))', new_line('a'), test%subject()
 
       end if
 


### PR DESCRIPTION
This commit replaces list-directed printing of the test_t subject with formatted printing to work around flang's relatively short wrapping length for list-directed printing.