### PR TITLE
Feature: construct `string_t` objects from logical & complex arguments

### DIFF
--- a/src/julienne/julienne_string_m.f90
+++ b/src/julienne/julienne_string_m.f90
@@ -2,6 +2,7 @@
 ! Terms of use are as specified in LICENSE.txt
 module julienne_string_m
   use assert_m, only : characterizable_t
+  use iso_c_binding, only : c_bool
   implicit none
   
   private
@@ -56,7 +57,7 @@ module julienne_string_m
 
   interface string_t
 
-    elemental module function construct(string) result(new_string)
+    elemental module function from_characters(string) result(new_string)
       implicit none
       character(len=*), intent(in) :: string
       type(string_t) new_string
@@ -77,6 +78,30 @@ module julienne_string_m
     elemental module function from_double_precision(x) result(string)
       implicit none
       double precision, intent(in) :: x
+      type(string_t) string
+    end function
+
+    elemental module function from_default_logical(b) result(string)
+      implicit none
+      logical, intent(in) :: b
+      type(string_t) string
+    end function
+
+    elemental module function from_logical_c_bool(b) result(string)
+      implicit none
+      logical(c_bool), intent(in) :: b
+      type(string_t) string
+    end function
+
+    elemental module function from_default_complex(z) result(string)
+      implicit none
+      complex, intent(in) :: z
+      type(string_t) string
+    end function
+
+    elemental module function from_double_precision_complex(z) result(string)
+      implicit none
+      complex(kind=kind(1D0)), intent(in) :: z
       type(string_t) string
     end function
 

--- a/src/julienne/julienne_string_s.f90
+++ b/src/julienne/julienne_string_s.f90
@@ -3,12 +3,11 @@
 submodule(julienne_string_m) julienne_string_s
   use assert_m, only : assert, intrinsic_array_t
   implicit none
+
+  integer, parameter :: integer_width_supremum = 11, default_real_width_supremum = 18, double_precision_width_supremum = 25
+  integer, parameter :: logical_width=2, comma_width = 1, parenthesis_width = 1, space=1
   
 contains
-
-  module procedure construct
-    new_string%string_ = string
-  end procedure
 
   module procedure as_character
     raw_string = self%string_
@@ -18,22 +17,50 @@ contains
     string_allocated = allocated(self%string_)
   end procedure
 
+  module procedure from_characters
+    new_string%string_ = string
+  end procedure
+
   module procedure from_default_integer
-    character(len=11) characters
-    write(characters, '(g0)') i
-    string = string_t(trim(characters))
+    allocate(character(len=integer_width_supremum) :: string%string_)
+    write(string%string_, '(g0)') i
+    string%string_ = trim(adjustl(string%string_))
   end procedure
 
   module procedure from_default_real
-    character(len=16) characters
-    write(characters, '(g0)') x
-    string = string_t(trim(characters))
+    allocate(character(len=double_precision_width_supremum) :: string%string_)
+    write(string%string_, '(g0)') x
+    string%string_ = trim(adjustl(string%string_))
   end procedure
 
   module procedure from_double_precision
-    character(len=24) characters
-    write(characters, '(g0)') x
-    string = string_t(trim(characters))
+    allocate(character(len=double_precision_width_supremum) :: string%string_)
+    write(string%string_, '(g0)') x
+    string%string_ = trim(adjustl(string%string_))
+  end procedure
+
+  module procedure from_default_logical
+    allocate(character(len=logical_width) :: string%string_)
+    write(string%string_, '(g0)') b
+    string%string_ = trim(adjustl(string%string_))
+  end procedure
+
+  module procedure from_logical_c_bool
+    allocate(character(len=logical_width) :: string%string_)
+    write(string%string_, '(g0)') b
+    string%string_ = trim(adjustl(string%string_))
+  end procedure
+
+  module procedure from_default_complex
+    allocate(character(len=2*default_real_width_supremum + 2*parenthesis_width + comma_width) :: string%string_)
+    write(string%string_, *) z
+    string%string_ = trim(adjustl(string%string_))
+  end procedure
+
+  module procedure from_double_precision_complex
+    allocate(character(len=space + 2*double_precision_width_supremum + 2*parenthesis_width + comma_width) :: string%string_)
+    write(string%string_, *) z
+    string%string_ = trim(adjustl(string%string_))
   end procedure
 
   module procedure concatenate_elements


### PR DESCRIPTION
This commit adds specific procedures supporting the `string_t` generic interface.  The new procedures take dummy arguments of the following types and kinds:
1. `logical`: default-kind and `c_bool
2. `complex`: default-kind and `double precision`

This commit also includes unit tests for each of the above four type/kind combinations.