### PR TITLE
test(test_description_t): temp nagfor workaround

### DIFF
--- a/test/test_description_test.F90
+++ b/test/test_description_test.F90
@@ -128,10 +128,14 @@ contains
       ,test_description_t("nothing to see here"      , unused) &
     ]
     tests_pass = [ &
-             test_descriptions(1)%contains_text(string_t("example")       ) &
-      ,      test_descriptions(2)%contains_text(         "example"        ) &
-      ,.not. test_descriptions(3)%contains_text(string_t("missing string")) &
-      ,.not. test_descriptions(4)%contains_text(         "missing string" ) &
+#ifndef NAGFOR
+             test_descriptions(1)%contains_text(string_t("example")       ), &
+#endif
+             test_descriptions(2)%contains_text(         "example"        ), &
+#ifndef NAGFOR
+       .not. test_descriptions(3)%contains_text(string_t("missing string")), &
+#endif
+       .not. test_descriptions(4)%contains_text(         "missing string" ) &
     ]
   end function
 


### PR DESCRIPTION
This commit uses the NAG compiler's predefined NAGFOR macro to remove two lines in test_description_test.F90 to work around a bug in the nagfor compiler. The compiler bug has been isolated and reported and the associated macro conditionals can be removed once a patched version of the compiler is available. In the interim, simply substituting character variables for string_t arguments in the test's contains_text check works around the issue.