### PR TITLE
Fix: work around gfortran 14.2.0 bug

### DIFF
--- a/src/julienne/julienne_string_m.f90
+++ b/src/julienne/julienne_string_m.f90
@@ -27,7 +27,7 @@ module julienne_string_m
     generic :: operator(/=)   => string_t_ne_string_t, string_t_ne_character, character_ne_string_t
     generic :: operator(==)   => string_t_eq_string_t, string_t_eq_character, character_eq_string_t
     generic :: assignment(= ) => assign_string_t_to_character, assign_character_to_string_t
-    generic :: get_json_value => get_string, get_string_t_array &
+    generic :: get_json_value => get_string, get_string_t_array_with_character_key, get_string_t_array_with_string_t_key &
                                 ,get_real, get_real_with_character_key &
                                 ,get_character, get_character_with_character_key &
                                 ,get_logical, get_logical_with_character_key  &
@@ -37,7 +37,7 @@ module julienne_string_m
                                 ,get_double_precision, get_double_precision_with_character_key &
                                 ,get_double_precision_array, get_double_precision_array_with_character_key
     procedure, private :: get_real, get_real_with_character_key
-    procedure, private :: get_string, get_string_t_array
+    procedure, private :: get_string, get_string_t_array_with_character_key, get_string_t_array_with_string_t_key
     procedure, private :: get_logical, get_logical_with_character_key
     procedure, private :: get_integer, get_integer_with_character_key
     procedure, private :: get_real_array, get_real_array_with_character_key
@@ -266,7 +266,14 @@ module julienne_string_m
       type(string_t) :: value_
     end function
 
-    pure module function get_string_t_array(self, key, mold) result(value_)
+    pure module function get_string_t_array_with_string_t_key(self, key, mold) result(value_)
+      implicit none
+      class(string_t), intent(in) :: self
+      type(string_t), intent(in) :: key, mold(:)
+      type(string_t), allocatable :: value_(:)
+    end function
+
+    pure module function get_string_t_array_with_character_key(self, key, mold) result(value_)
       implicit none
       class(string_t), intent(in) :: self
       character(len=*), intent(in) :: key

--- a/src/julienne/julienne_string_m.f90
+++ b/src/julienne/julienne_string_m.f90
@@ -268,7 +268,8 @@ module julienne_string_m
 
     pure module function get_string_t_array(self, key, mold) result(value_)
       implicit none
-      class(string_t), intent(in) :: self, key
+      class(string_t), intent(in) :: self
+      character(len=*), intent(in) :: key
       type(string_t), intent(in) :: mold(:)
       type(string_t), allocatable :: value_(:)
     end function

--- a/src/julienne/julienne_string_s.f90
+++ b/src/julienne/julienne_string_s.f90
@@ -242,7 +242,7 @@ contains
     associate(colon => index(raw_line, ':'))
       associate(opening_bracket => colon + index(raw_line(colon+1:), '['))
         associate(closing_bracket => opening_bracket + index(raw_line(opening_bracket+1:), ']'))
-          associate(commas => count("," == [(raw_line(i:i), i = opening_bracket+1, closing_bracket-1)]))
+          associate(commas => count([(raw_line(i:i)==",", i = opening_bracket+1, closing_bracket-1)]))
             allocate(value_(commas+1))
             opening_quotes = opening_bracket + index(raw_line(opening_bracket+1:), '"')
             closing_quotes = opening_quotes + index(raw_line(opening_quotes+1:), '"')

--- a/src/julienne/julienne_string_s.f90
+++ b/src/julienne/julienne_string_s.f90
@@ -230,7 +230,11 @@ contains
     end associate
   end procedure
 
-  module procedure get_string_t_array
+  module procedure get_string_t_array_with_string_t_key
+    value_ = self%get_string_t_array_with_character_key(key%string(), mold)
+  end procedure
+
+  module procedure get_string_t_array_with_character_key
 
     character(len=:), allocatable :: raw_line
     integer i, comma, opening_quotes, closing_quotes

--- a/test/string_test.F90
+++ b/test/string_test.F90
@@ -113,8 +113,7 @@ contains
       constructs_from_double_precision_complex_ptr, &
       concatenates_ptr, extracts_key_ptr, extracts_real_ptr, extracts_string_ptr, extracts_logical_ptr, extracts_integer_array_ptr, &
       extracts_real_array_ptr, extracts_integer_ptr, extracts_file_base_ptr, extracts_file_name_ptr, &
-      ! Remove code that exposes a gfortran compiler bug:
-      ! extracts_string_array_ptr, &
+      extracts_string_array_ptr, &
       extracts_character_ptr, extracts_double_precision_value_ptr, extracts_dp_array_value_ptr, &
       brackets_strings_ptr, constructs_separated_values_ptr
         
@@ -139,8 +138,7 @@ contains
     extracts_character_ptr => extracts_character_value
     extracts_logical_ptr => extracts_logical_value
     extracts_integer_array_ptr  => extracts_integer_array_value
-   ! Remove code that exposes a gfortran compiler bug:
-   !extracts_string_array_ptr  => extracts_string_array_value
+    extracts_string_array_ptr  => extracts_string_array_value
     extracts_real_array_ptr => extracts_real_array_value
     extracts_dp_array_value_ptr => extracts_dp_array_value
     extracts_integer_ptr => extracts_integer_value
@@ -176,9 +174,8 @@ contains
       test_description_t(string_t("extracting a logical value from a colon-separated key/value pair"), extracts_logical_ptr), &
       test_description_t( &
         string_t("extracting an integer array value from a colon-separated key/value pair"), extracts_integer_array_ptr), &
-     ! Remove code that exposes a gfortran compiler bug:
-     !test_description_t( &
-     !  string_t("extracting an string array value from a colon-separated key/value pair"), extracts_string_array_ptr), &
+      test_description_t( &
+        string_t("extracting an string array value from a colon-separated key/value pair"), extracts_string_array_ptr), &
       test_description_t( &
         string_t("extracting an real array value from a colon-separated key/value pair"), extracts_real_array_ptr), &
       test_description_t( &
@@ -344,13 +341,12 @@ contains
 #endif
   end function
 
-#ifndef __GFORTRAN__
   function extracts_string_array_value() result(passed)
     logical passed
 
 #ifndef _CRAYFTN
     associate(key_string_array_pair => string_t('"lead singer" : ["stevie", "ray", "vaughn"],'))
-      associate(string_array => key_string_array_pair%get_json_value(key=string_t("lead singer"), mold=[string_t::]))
+      associate(string_array => key_string_array_pair%get_json_value(key="lead singer", mold=[string_t::]))
         passed = all(string_array == [string_t("stevie"), string_t("ray"), string_t("vaughn")])
       end associate
     end associate
@@ -364,7 +360,6 @@ contains
     end block
 #endif
   end function
-#endif
 
   function extracts_integer_array_value() result(passed)
     logical passed

--- a/test/string_test.F90
+++ b/test/string_test.F90
@@ -347,7 +347,14 @@ contains
 #ifndef _CRAYFTN
     associate(key_string_array_pair => string_t('"lead singer" : ["stevie", "ray", "vaughn"],'))
       associate(string_array => key_string_array_pair%get_json_value(key="lead singer", mold=[string_t::]))
-        passed = all(string_array == [string_t("stevie"), string_t("ray"), string_t("vaughn")])
+#ifndef __GFORTRAN__
+        associate(string_array_ => key_string_array_pair%get_json_value(key=string_t("lead singer"), mold=[string_t::]))
+#endif
+          passed = all(string_array == [string_t("stevie"), string_t("ray"), string_t("vaughn")])
+#ifndef __GFORTRAN__
+                  & .and. all(string_array_ == [string_t("stevie"), string_t("ray"), string_t("vaughn")])
+        end associate
+#endif
       end associate
     end associate
 #else


### PR DESCRIPTION
This PR works around a `gfortran` 14.2.0 bug [118750] and enables a test that was previously disabled because of the bug. 

[118750]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118750