### PR TITLE
test(string_t): fix line continuation

### DIFF
--- a/test/string_test.F90
+++ b/test/string_test.F90
@@ -352,7 +352,7 @@ contains
 #endif
           passed = all(string_array == [string_t("stevie"), string_t("ray"), string_t("vaughn")])
 #ifndef __GFORTRAN__
-                  & .and. all(string_array_ == [string_t("stevie"), string_t("ray"), string_t("vaughn")])
+          passed = passed .and. all(string_array_ == [string_t("stevie"), string_t("ray"), string_t("vaughn")])
         end associate
 #endif
       end associate


### PR DESCRIPTION
This commit fixes a problem with line continuation in string_test.F90 identified by the NAG compiler.