### PR TITLE
Feature: Skip tests and report skipped tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Building and Testing
 ### GNU (`gfortran`)
 #### `gfortran` versions 14 or higher
 ```
-fpm test --compiler gfortran --profile release 
+fpm test --compiler gfortran --profile release
 ```
 
 #### `gfortran` versions 13

--- a/example/example-test-suite/main.F90
+++ b/example/example-test-suite/main.F90
@@ -10,10 +10,10 @@ program main
   implicit none
 
   type(specimen_test_t) specimen_test
-  integer :: passes=0, tests=0
+  integer :: passes=0, tests=0, skips=0
 
   call print_usage_and_stop_if_help_requested
-  call specimen_test%report(passes, tests)
+  call specimen_test%report(passes, tests, skips)
   call report_tally_and_error_stop_if_test_fails
 
 contains
@@ -40,7 +40,7 @@ contains
     if (this_image()==1) then
 #endif
       print *
-      print '(*(a,:,g0))', "_________ In total, ",passes," of ",tests, " tests pass. _________"
+      print '(*(a,:,g0))', "_________ In total, ",passes," of ",tests, " tests pass. ", skips , " tests were skipped _________"
       if (passes /= tests) error stop "Some tests failed."
 #if HAVE_MULTI_IMAGE_SUPPORT
     end if

--- a/src/julienne/julienne_test_description_m.f90
+++ b/src/julienne/julienne_test_description_m.f90
@@ -36,19 +36,19 @@ module julienne_test_description_m
 
   interface test_description_t
 
-    module function construct_from_string_t_and_diagnosis_function(description, diagnosis_function) result(test_description)
+    module function construct_from_string(description, diagnosis_function) result(test_description)
       !! The result is a test_description_t object with the components defined by the dummy arguments
       implicit none
       type(string_t), intent(in) :: description
-      procedure(diagnosis_function_i), intent(in), pointer :: diagnosis_function
+      procedure(diagnosis_function_i), intent(in), pointer, optional :: diagnosis_function
       type(test_description_t) test_description
     end function
 
-    module function construct_from_character_and_diagnosis_function(description, diagnosis_function) result(test_description)
+    module function construct_from_characters(description, diagnosis_function) result(test_description)
       !! The result is a test_description_t object with the components defined by the dummy arguments
       implicit none
       character(len=*), intent(in) :: description
-      procedure(diagnosis_function_i), intent(in), pointer :: diagnosis_function
+      procedure(diagnosis_function_i), intent(in), pointer, optional :: diagnosis_function
       type(test_description_t) test_description
     end function
 

--- a/src/julienne/julienne_test_description_s.F90
+++ b/src/julienne/julienne_test_description_s.F90
@@ -8,24 +8,25 @@ submodule(julienne_test_description_m) julienne_test_description_s
   implicit none
 contains
 
-    module procedure construct_from_character_and_diagnosis_function
+    module procedure construct_from_characters
       test_description%description_ = description
-      test_description%diagnosis_function_ => diagnosis_function
-      call_assert(associated(test_description%diagnosis_function_))
+      if (present(diagnosis_function)) test_description%diagnosis_function_ => diagnosis_function
       call_assert(allocated(test_description%description_))
     end procedure
 
-    module procedure construct_from_string_t_and_diagnosis_function
+    module procedure construct_from_string
       test_description%description_ = description
-      test_description%diagnosis_function_ => diagnosis_function
-      call_assert(associated(test_description%diagnosis_function_))
+      if (present(diagnosis_function)) test_description%diagnosis_function_ => diagnosis_function
       call_assert(allocated(test_description%description_))
     end procedure
 
     module procedure run
       call_assert(allocated(self%description_))
-      call_assert(associated(self%diagnosis_function_))
-      test_result = test_result_t(self%description_, self%diagnosis_function_())
+      if (associated(self%diagnosis_function_)) then
+        test_result = test_result_t(self%description_, self%diagnosis_function_())
+      else
+        test_result = test_result_t(self%description_)
+      end if
     end procedure
 
     module procedure contains_string_t
@@ -40,7 +41,8 @@ contains
 
     module procedure equals
       call_assert(allocated(lhs%description_) .and. allocated(rhs%description_))
-      call_assert(associated(lhs%diagnosis_function_) .and. associated(rhs%diagnosis_function_))
-      lhs_eq_rhs = (lhs%description_ == rhs%description_) .and. associated(lhs%diagnosis_function_, rhs%diagnosis_function_)
+      lhs_eq_rhs = (lhs%description_ == rhs%description_)
+      if (associated(lhs%diagnosis_function_) .and. associated(rhs%diagnosis_function_)) &
+        lhs_eq_rhs = lhs_eq_rhs .and. associated(lhs%diagnosis_function_, rhs%diagnosis_function_)
     end procedure
 end submodule julienne_test_description_s

--- a/src/julienne/julienne_test_m.F90
+++ b/src/julienne/julienne_test_m.F90
@@ -43,11 +43,11 @@ module julienne_test_m
 
   interface
 
-    module subroutine report(test, passes, tests)
-      !! Print the test results and increment the tallies of passing tests and total tests
+    module subroutine report(test, passes, tests, skips)
+      !! Print the test results and increment the tallies of passing tests, total tests, and skipped tests.
       implicit none
       class(test_t), intent(in) :: test
-      integer, intent(inout) :: passes, tests
+      integer, intent(inout) :: passes, tests, skips
     end subroutine
 
   end interface

--- a/src/julienne/julienne_test_result_m.f90
+++ b/src/julienne/julienne_test_result_m.f90
@@ -17,6 +17,7 @@ module julienne_test_result_m
   contains
     procedure :: characterize
     procedure :: passed
+    procedure :: skipped
     generic :: description_contains => description_contains_string, description_contains_characters
     procedure, private :: description_contains_string
     procedure, private :: description_contains_characters
@@ -56,6 +57,13 @@ module julienne_test_result_m
       implicit none
       class(test_result_t), intent(in) :: self
       logical test_passed
+    end function
+
+    impure elemental module function skipped(self) result(test_skipped)
+      !! The result is true if and only if the test result contains no diagnosis on any image
+      implicit none
+      class(test_result_t), intent(in) :: self
+      logical test_skipped
     end function
 
     elemental module function description_contains_string(self, substring) result(substring_found)

--- a/src/julienne/julienne_test_result_m.f90
+++ b/src/julienne/julienne_test_result_m.f90
@@ -13,7 +13,7 @@ module julienne_test_result_m
     !! Encapsulate test descriptions and outcomes
     private
     type(string_t) :: description_
-    type(test_diagnosis_t)diagnostics_
+    type(test_diagnosis_t), allocatable :: diagnosis_
   contains
     procedure :: characterize
     procedure :: passed
@@ -24,19 +24,19 @@ module julienne_test_result_m
 
   interface test_result_t
 
-    elemental module function construct_from_string_and_diagnosis(description, diagnosis) result(test_result)
+    elemental module function construct_from_string(description, diagnosis) result(test_result)
       !! The result is a test_result_t object with the components defined by the dummy arguments
       implicit none
       type(string_t), intent(in) :: description
-      type(test_diagnosis_t), intent(in) :: diagnosis
+      type(test_diagnosis_t), intent(in), optional :: diagnosis
       type(test_result_t) test_result 
     end function
 
-    elemental module function construct_from_character_and_diagnosis(description, diagnosis) result(test_result)
+    elemental module function construct_from_character(description, diagnosis) result(test_result)
       !! The result is a test_result_t object with the components defined by the dummy arguments
       implicit none
       character(len=*), intent(in) :: description
-      type(test_diagnosis_t), intent(in) :: diagnosis
+      type(test_diagnosis_t), intent(in), optional :: diagnosis
       type(test_result_t) test_result 
     end function
 

--- a/src/julienne/julienne_test_result_s.f90
+++ b/src/julienne/julienne_test_result_s.f90
@@ -37,6 +37,11 @@ contains
       call co_all(test_passed)
     end procedure
 
+    module procedure skipped
+      test_skipped = merge(.false., .true., allocated(self%diagnosis_))
+      call co_all(test_skipped)
+    end procedure
+
     module procedure description_contains_string
       substring_found = self%description_contains_characters(substring%string())
     end procedure

--- a/src/julienne/julienne_test_s.F90
+++ b/src/julienne/julienne_test_s.F90
@@ -55,12 +55,18 @@ contains
             end block
           end if
           block
-            logical, allocatable :: passing_tests(:)
+            logical, allocatable :: passing_tests(:), skipped_tests(:)
+
             passing_tests = test_results%passed()
+            skipped_tests = test_results%skipped()
+
             call co_all(passing_tests)
-            associate(num_passes => count(passing_tests))
-              if (me==1) print '(a,2(i0,a))'," ",num_passes," of ", num_tests," tests pass."
+            call co_all(skipped_tests)
+
+            associate(num_passes => count(passing_tests), num_skipped => count(skipped_tests))
+              if (me==1) print '(a,3(i0,a))'," ",num_passes," of ", num_tests," tests pass.", num_skipped, " tests skipped."
               passes = passes + num_passes
+              skips  = skips  + num_skipped
             end associate
           end block
         end associate

--- a/src/julienne/julienne_test_s.F90
+++ b/src/julienne/julienne_test_s.F90
@@ -64,7 +64,7 @@ contains
             call co_all(skipped_tests)
 
             associate(num_passes => count(passing_tests), num_skipped => count(skipped_tests))
-              if (me==1) print '(a,3(i0,a))'," ",num_passes," of ", num_tests," tests pass.", num_skipped, " tests skipped."
+              if (me==1) print '(a,3(i0,a))'," ",num_passes," of ", num_tests," tests pass.  ", num_skipped, " tests were skipped."
               passes = passes + num_passes
               skips  = skips  + num_skipped
             end associate

--- a/src/julienne/julienne_vector_test_description_m.F90
+++ b/src/julienne/julienne_vector_test_description_m.F90
@@ -25,7 +25,7 @@ module julienne_vector_test_description_m
   type vector_test_description_t
     private
     type(string_t), allocatable :: descriptions_(:)
-    procedure(vector_diagnosis_function_i), pointer, nopass :: vector_diagnosis_function_
+    procedure(vector_diagnosis_function_i), pointer, nopass :: vector_diagnosis_function_ => null()
   contains
     procedure run
     procedure contains_text
@@ -37,7 +37,7 @@ module julienne_vector_test_description_m
      !! The result is a vector_test_description_t object with the components defined by the dummy arguments
       implicit none
       type(string_t), intent(in) :: descriptions(:)
-      procedure(vector_diagnosis_function_i), intent(in), pointer :: vector_diagnosis_function
+      procedure(vector_diagnosis_function_i), intent(in), pointer, optional :: vector_diagnosis_function
       type(vector_test_description_t) vector_test_description
     end function
 

--- a/test/main.F90
+++ b/test/main.F90
@@ -67,7 +67,7 @@ program main
 #endif
 
     print *
-    print '(*(a,:,g0))', "_________ In total, ",passes," of ",tests, " tests pass. ", skips, " tests were skipped. _________"
+    print '(*(a,:,g0))', "_________ In total, ",passes," of ",tests, " tests pass.  ", skips, " tests were skipped. _________"
 
     if (passes + skips /= tests) error stop "Some executed tests failed."
 

--- a/test/main.F90
+++ b/test/main.F90
@@ -29,7 +29,7 @@ program main
 
   type(command_line_t) command_line
 
-  integer :: passes=0, tests=0
+  integer :: passes=0, tests=0, skips=0
 
   character(len=*), parameter :: usage = &
     new_line('') // new_line('') // &
@@ -43,16 +43,16 @@ program main
 
   print "(a)", new_line("") // "Append '-- --help' or '-- -h' to your `fpm test` command to display usage information."
 
-  call bin_test%report(passes, tests)
-  call formats_test%report(passes, tests)
-  call string_test%report(passes, tests)
-  call test_result_test%report(passes, tests)
-  call test_description_test%report(passes, tests)
-  call vector_test_description_test%report(passes,tests)
+  call bin_test%report(passes, tests, skips)
+  call formats_test%report(passes, tests, skips)
+  call string_test%report(passes, tests, skips)
+  call test_result_test%report(passes, tests, skips)
+  call test_description_test%report(passes, tests, skips)
+  call vector_test_description_test%report(passes,tests, skips)
 
   if (.not. GitHub_CI())  then
     if (command_line%argument_present(["--test"])) then
-      call command_line_test%report(passes, tests)
+      call command_line_test%report(passes, tests, skips)
     else
       write(*,"(a)")  &
       new_line("") // &
@@ -67,9 +67,9 @@ program main
 #endif
 
     print *
-    print '(*(a,:,g0))', "_________ In total, ",passes," of ",tests, " tests pass. _________"
+    print '(*(a,:,g0))', "_________ In total, ",passes," of ",tests, " tests pass. ", skips, " tests were skipped. _________"
 
-    if (passes /= tests) error stop "Some tests failed."
+    if (passes + skips /= tests) error stop "Some executed tests failed."
 
 #if HAVE_MULTI_IMAGE_SUPPORT
   end if

--- a/test/string_test_m.F90
+++ b/test/string_test_m.F90
@@ -166,14 +166,15 @@ contains
       ,test_description_t('supporting unary operator(.cat.) for array arguments',                            concatenates_elements_ptr)&
 #ifndef __GFORTRAN__
       ,test_description_t('constructing bracketed strings',                                                       brackets_strings_ptr)&
+#else
+      ! Because this test crashes due to a gfortran bug, we construct the test_descriptoin_t object without a test_diagnosis_t
+      ! function, which will cause the test to be skipped and reported as such in test_result_t's "run" function.
+      ,test_description_t('constructing bracketed strings'                                                                            )&
 #endif
       ,test_description_t("extracting a string_t array value from a colon-separated key/value pair",   extracts_string_array_value_ptr)&
       ,test_description_t('constructing (comma-)separated values from character or string_t arrays',   constructs_separated_values_ptr)&
       ,test_description_t('constructing from a double-precision complex value',           constructs_from_double_precision_complex_ptr)&
     ]
-#endif
-#ifdef __GFORTRAN__
-    print *,"  skips  on testing the bracket() function due to a compiler bug (see https://go.lbl.gov/gcc-bug-119349)."
 #endif
     test_descriptions = pack(test_descriptions, &
       index(subject(), test_description_substring) /= 0 .or. &

--- a/test/vector_test_description_test_m.F90
+++ b/test/vector_test_description_test_m.F90
@@ -49,14 +49,13 @@ contains
       )]) 
 #else
       block
-       type(vector_test_description_t), allocatable :: vector_test_descriptions(:)
+       type(vector_test_description_t) vector_test_descriptions(1)
 
-        vector_test_descriptions = [ &
-          vector_test_description_t( [ &
-             string_t(    "finding a substring in a test description") &
-            ,string_t("not finding a missing substring in a test description") &
-        ])]
-
+       vector_test_descriptions(1) = &
+         vector_test_description_t( [ &
+            string_t(    "finding a substring in a test description") &
+           ,string_t("not finding a missing substring in a test description") &
+       ])
 #endif
         associate(num_vector_tests => size(vector_test_descriptions))
           block

--- a/test/vector_test_description_test_m.F90
+++ b/test/vector_test_description_test_m.F90
@@ -48,19 +48,33 @@ contains
         ], check_substring_search &
       )]) 
 #else
-      associate(vector_test_descriptions => [vector_test_description_t::])
-        print '(a)',"  skips  on testing vector_test_description_t due to a compiler bug "
+      block
+       type(vector_test_description_t), allocatable :: vector_test_descriptions(:)
+
+        vector_test_descriptions = [ &
+          vector_test_description_t( [ &
+             string_t(    "finding a substring in a test description") &
+            ,string_t("not finding a missing substring in a test description") &
+        ])]
+
 #endif
         associate(num_vector_tests => size(vector_test_descriptions))
           block
             integer i
-           
+
             if (substring_in_subject) then
               test_results = [(vector_test_descriptions(i)%run(), i=1,num_vector_tests)]
             else
+#ifndef __GFORTRAN__
               associate(substring_in_description_vector => &
                 [(any(vector_test_descriptions(i)%contains_text(test_description_substring)), i=1,num_vector_tests)] &
               )
+#else
+              block
+                logical, allocatable :: substring_in_description_vector(:)
+                substring_in_description_vector = &
+                  [(any(vector_test_descriptions(i)%contains_text(test_description_substring)), i=1,num_vector_tests)]
+#endif
 #ifndef __GFORTRAN__
                 associate(matching_vector_tests => pack(vector_test_descriptions, substring_in_description_vector))
                   associate(results_with_matches => [(matching_vector_tests(i)%run(), i=1,size(matching_vector_tests))])
@@ -76,11 +90,19 @@ contains
                     test_results = pack(results_with_matches, results_with_matches%description_contains(test_description_substring))
                   end block
 #endif
+#ifndef __GFORTRAN__
               end associate
+#else
+              end block
+#endif
             end if
           end block
         end associate
+#ifndef __GFORTRAN__
       end associate
+#else
+      end block
+#endif
     end associate
   end function
 


### PR DESCRIPTION
This PR automates test-skipping, which is useful, for example, when a test that crashes with a specific compiler.  The `test_description_t` and `vector_test_description_t` constructors' `diagnosis_function` and `vector_diagnosic_function` arguments, respectively, now have the `optional` attribute.  When these arguments are not `present`, no diagnostic function executes, resulting in `test_result_t` type's `run` procedure reporting the test as skipped.  

Currently, both of Julienne's `vector_test_description_t` tests are skipped when the `gfortran` compiler is detected.  Reporting the tests as skipped when Julienne's test suite is executed serves to highlight that we cannot currently support the use of `vector_test_description_t` with `gfortran`.  Related compiler bugs have been reported. We expect to support vector tests (tests that produce more than one diagnosis) once the blocking compiler bugs have been fixed.