### PR TITLE
Feature: support comparison expressions that evaluate to test diagnoses

### DIFF
--- a/include/language-support.F90
+++ b/include/language-support.F90
@@ -1,32 +1,38 @@
 ! Copyright (c) 2024-2025, The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 
+#ifndef _JULIENNE_LANGUAGE_SUPPORT_H
+#define _JULIENNE_LANGUAGE_SUPPORT_H
+
+! If not already determined, make a compiler-dependent determination of whether Julienne may pass
+! procedure actual arguments to procedure pointer dummy arguments, a feature introduced in
+! Fortran 2008 and described in Fortran 2023 clause 15.5.2.10 paragraph 5.
 #ifndef HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
-  ! Define whether the compiler supports associating a procedure pointer dummy argument with an
-  ! actual argument that is a valid target for the pointer dummy in a procedure assignment, a
-  ! feature introduced in Fortran 2008 and described in Fortran 2023 clause 15.5.2.10 paragraph 5.
-#if defined(_CRAYFTN) || defined(__INTEL_COMPILER) || defined(NAGFOR) || defined(__flang__)
-#define HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY 1
-#else
-#define HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY 0
-#endif
+#  if defined(__GFORTRAN__)
+#    define HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY 0
+#  else
+#    define HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY 1
+#  endif
 #endif
 
+! If not already determined, make a compiler-dependent determination of whether Julienne may use
+! multi-image features such as `this_image()` and `sync all`.
 #ifndef HAVE_MULTI_IMAGE_SUPPORT
-  ! Define whether the compiler supports the statements and intrinsic procedures that support
-  ! multi-image execution, e.g., this_image(), sync all, etc.
-#if defined(_CRAYFTN) || defined(__INTEL_COMPILER) || defined(NAGFOR) || defined(__GFORTRAN__)
-#define HAVE_MULTI_IMAGE_SUPPORT 1
-#else
-#define HAVE_MULTI_IMAGE_SUPPORT 0
-#endif
+#  if defined(__flang__)
+#    define HAVE_MULTI_IMAGE_SUPPORT 0
+#  else
+#    define HAVE_MULTI_IMAGE_SUPPORT 1
+#  endif
 #endif
 
+! If not already determined, make a compiler-dependent determination of whether Julienne may use
+! kind type parameters for derived types.
 #ifndef HAVE_DERIVED_TYPE_KIND_PARAMETERS
-  ! Define whether the compiler has sufficient support for kind type parameters for derived types
-#if defined(_CRAYFTN) || defined(__INTEL_COMPILER) || defined(NAGFOR)
-#define HAVE_DERIVED_TYPE_KIND_PARAMETERS 1
-#else
-#define HAVE_DERIVED_TYPE_KIND_PARAMETERS 0
+#  if defined(__GFORTRAN__)
+#    define HAVE_DERIVED_TYPE_KIND_PARAMETERS 0
+#  else
+#    define HAVE_DERIVED_TYPE_KIND_PARAMETERS 1
+#  endif
 #endif
+
 #endif

--- a/include/language-support.F90
+++ b/include/language-support.F90
@@ -21,3 +21,12 @@
 #define HAVE_MULTI_IMAGE_SUPPORT 0
 #endif
 #endif
+
+#ifndef HAVE_DERIVED_TYPE_KIND_PARAMETERS
+  ! Define whether the compiler has sufficient support for kind type parameters for derived types
+#if defined(_CRAYFTN) || defined(__INTEL_COMPILER) || defined(NAGFOR)
+#define HAVE_DERIVED_TYPE_KIND_PARAMETERS 1
+#else
+#define HAVE_DERIVED_TYPE_KIND_PARAMETERS 0
+#endif
+#endif

--- a/src/julienne/julienne_test_diagnosis_m.F90
+++ b/src/julienne/julienne_test_diagnosis_m.F90
@@ -13,6 +13,7 @@ module julienne_test_diagnosis_m
   public :: operator(.approximates.)
   public :: operator(.within.)
   public :: operator(.equalsExpected.)
+  public :: operator(.lessThan.)
 
   type test_diagnosis_t
     !! Encapsulate test outcome and diagnostic information
@@ -66,6 +67,28 @@ module julienne_test_diagnosis_m
     pure module function equals_expected_integer(actual, expected) result(test_diagnosis)
       implicit none
       integer, intent(in) :: actual, expected
+      type(test_diagnosis_t) test_diagnosis
+    end function
+
+  end interface
+
+  interface operator(.lessThan.)
+
+    pure module function less_than_real(actual, expected_ceiling) result(test_diagnosis)
+      implicit none
+      real, intent(in) :: actual, expected_ceiling
+      type(test_diagnosis_t) test_diagnosis
+    end function
+
+    pure module function less_than_double(actual, expected_ceiling) result(test_diagnosis)
+      implicit none
+      double precision, intent(in) :: actual, expected_ceiling
+      type(test_diagnosis_t) test_diagnosis
+    end function
+
+    pure module function less_than_integer(actual, expected_ceiling) result(test_diagnosis)
+      implicit none
+      integer, intent(in) :: actual, expected_ceiling
       type(test_diagnosis_t) test_diagnosis
     end function
 

--- a/src/julienne/julienne_test_diagnosis_m.F90
+++ b/src/julienne/julienne_test_diagnosis_m.F90
@@ -1,5 +1,8 @@
 ! Copyright (c) 2024-2025, The Regents of the University of California and Sourcery Institute
 ! Terms of use are as specified in LICENSE.txt
+
+#include "language-support.F90"
+
 module julienne_test_diagnosis_m
   !! Define an abstraction for describing test outcomes and diagnostic information
   use julienne_string_m, only : string_t
@@ -23,10 +26,20 @@ module julienne_test_diagnosis_m
 
   integer, parameter :: default_real = kind(1.), double_precision = kind(1D0)
 
+#if HAVE_DERIVED_TYPE_KIND_PARAMETERS
   type operands_t(k)
     integer, kind :: k = default_real
     real(k) actual, expected 
   end type
+#else
+  type operands_t
+    real actual, expected 
+  end type
+
+  type double_precision_operands_t
+    double precision actual, expected 
+  end type
+#endif
 
   interface operator(.approximates.)
 
@@ -39,7 +52,11 @@ module julienne_test_diagnosis_m
     pure module function approximates_double_precision(actual, expected) result(operands)
       implicit none
       double precision, intent(in) :: actual, expected
+#if HAVE_DERIVED_TYPE_KIND_PARAMETERS
       type(operands_t(double_precision)) operands
+#else
+      type(double_precision_operands_t) operands
+#endif
     end function
 
   end interface
@@ -65,7 +82,11 @@ module julienne_test_diagnosis_m
    
     pure module function within_double_precision(operands, tolerance) result(test_diagnosis)
       implicit none
+#if HAVE_DERIVED_TYPE_KIND_PARAMETERS
       type(operands_t(double_precision)), intent(in) :: operands
+#else
+      type(double_precision_operands_t), intent(in) :: operands
+#endif
       double precision, intent(in) :: tolerance
       type(test_diagnosis_t) test_diagnosis
     end function

--- a/src/julienne/julienne_test_diagnosis_m.F90
+++ b/src/julienne/julienne_test_diagnosis_m.F90
@@ -14,6 +14,9 @@ module julienne_test_diagnosis_m
   public :: operator(.within.)
   public :: operator(.equalsExpected.)
   public :: operator(.lessThan.)
+  public :: operator(.lessThanOrEqualTo.)
+  public :: operator(.greaterThan.)
+  public :: operator(.greaterThanOrEqualTo.)
 
   type test_diagnosis_t
     !! Encapsulate test outcome and diagnostic information
@@ -89,6 +92,48 @@ module julienne_test_diagnosis_m
     pure module function less_than_integer(actual, expected_ceiling) result(test_diagnosis)
       implicit none
       integer, intent(in) :: actual, expected_ceiling
+      type(test_diagnosis_t) test_diagnosis
+    end function
+
+  end interface
+
+  interface operator(.lessThanOrEqualTo.)
+
+    pure module function less_than_or_equal_to_integer(actual, expected_max) result(test_diagnosis)
+      implicit none
+      integer, intent(in) :: actual, expected_max
+      type(test_diagnosis_t) test_diagnosis
+    end function
+
+  end interface
+
+  interface operator(.greaterThanOrEqualTo.)
+
+    pure module function greater_than_or_equal_to_integer(actual, expected_min) result(test_diagnosis)
+      implicit none
+      integer, intent(in) :: actual, expected_min
+      type(test_diagnosis_t) test_diagnosis
+    end function
+
+  end interface
+
+  interface operator(.greaterThan.)
+
+    pure module function greater_than_real(actual, expected_floor) result(test_diagnosis)
+      implicit none
+      real, intent(in) :: actual, expected_floor
+      type(test_diagnosis_t) test_diagnosis
+    end function
+
+    pure module function greater_than_double(actual, expected_floor) result(test_diagnosis)
+      implicit none
+      double precision, intent(in) :: actual, expected_floor
+      type(test_diagnosis_t) test_diagnosis
+    end function
+
+    pure module function greater_than_integer(actual, expected_floor) result(test_diagnosis)
+      implicit none
+      integer, intent(in) :: actual, expected_floor
       type(test_diagnosis_t) test_diagnosis
     end function
 

--- a/src/julienne/julienne_test_diagnosis_m.F90
+++ b/src/julienne/julienne_test_diagnosis_m.F90
@@ -10,6 +10,7 @@ module julienne_test_diagnosis_m
 
   private
   public :: test_diagnosis_t
+  public :: operator(.all.)
   public :: operator(.approximates.)
   public :: operator(.within.)
   public :: operator(.equalsExpected.)
@@ -44,6 +45,16 @@ module julienne_test_diagnosis_m
     double precision actual, expected 
   end type
 #endif
+
+  interface operator(.all.)
+     
+    pure module function aggregate_diagnosis(diagnoses) result(diagnosis)
+      implicit none
+      type(test_diagnosis_t), intent(in) :: diagnoses(..)
+      type(test_diagnosis_t) diagnosis
+    end function
+
+  end interface
 
   interface operator(.approximates.)
 
@@ -99,7 +110,7 @@ module julienne_test_diagnosis_m
 
   interface operator(.lessThanOrEqualTo.)
 
-    pure module function less_than_or_equal_to_integer(actual, expected_max) result(test_diagnosis)
+    elemental module function less_than_or_equal_to_integer(actual, expected_max) result(test_diagnosis)
       implicit none
       integer, intent(in) :: actual, expected_max
       type(test_diagnosis_t) test_diagnosis
@@ -109,7 +120,7 @@ module julienne_test_diagnosis_m
 
   interface operator(.greaterThanOrEqualTo.)
 
-    pure module function greater_than_or_equal_to_integer(actual, expected_min) result(test_diagnosis)
+    elemental module function greater_than_or_equal_to_integer(actual, expected_min) result(test_diagnosis)
       implicit none
       integer, intent(in) :: actual, expected_min
       type(test_diagnosis_t) test_diagnosis

--- a/src/julienne/julienne_test_diagnosis_m.F90
+++ b/src/julienne/julienne_test_diagnosis_m.F90
@@ -58,13 +58,13 @@ module julienne_test_diagnosis_m
 
   interface operator(.approximates.)
 
-    pure module function approximates_real(actual, expected) result(operands)
+    elemental module function approximates_real(actual, expected) result(operands)
       implicit none
       real, intent(in) :: actual, expected
       type(operands_t) operands
     end function
 
-    pure module function approximates_double_precision(actual, expected) result(operands)
+    elemental module function approximates_double_precision(actual, expected) result(operands)
       implicit none
       double precision, intent(in) :: actual, expected
 #if HAVE_DERIVED_TYPE_KIND_PARAMETERS
@@ -78,7 +78,7 @@ module julienne_test_diagnosis_m
 
   interface operator(.equalsExpected.)
 
-    pure module function equals_expected_integer(actual, expected) result(test_diagnosis)
+    elemental module function equals_expected_integer(actual, expected) result(test_diagnosis)
       implicit none
       integer, intent(in) :: actual, expected
       type(test_diagnosis_t) test_diagnosis
@@ -88,19 +88,19 @@ module julienne_test_diagnosis_m
 
   interface operator(.lessThan.)
 
-    pure module function less_than_real(actual, expected_ceiling) result(test_diagnosis)
+    elemental module function less_than_real(actual, expected_ceiling) result(test_diagnosis)
       implicit none
       real, intent(in) :: actual, expected_ceiling
       type(test_diagnosis_t) test_diagnosis
     end function
 
-    pure module function less_than_double(actual, expected_ceiling) result(test_diagnosis)
+    elemental module function less_than_double(actual, expected_ceiling) result(test_diagnosis)
       implicit none
       double precision, intent(in) :: actual, expected_ceiling
       type(test_diagnosis_t) test_diagnosis
     end function
 
-    pure module function less_than_integer(actual, expected_ceiling) result(test_diagnosis)
+    elemental module function less_than_integer(actual, expected_ceiling) result(test_diagnosis)
       implicit none
       integer, intent(in) :: actual, expected_ceiling
       type(test_diagnosis_t) test_diagnosis
@@ -130,19 +130,19 @@ module julienne_test_diagnosis_m
 
   interface operator(.greaterThan.)
 
-    pure module function greater_than_real(actual, expected_floor) result(test_diagnosis)
+    elemental module function greater_than_real(actual, expected_floor) result(test_diagnosis)
       implicit none
       real, intent(in) :: actual, expected_floor
       type(test_diagnosis_t) test_diagnosis
     end function
 
-    pure module function greater_than_double(actual, expected_floor) result(test_diagnosis)
+    elemental module function greater_than_double(actual, expected_floor) result(test_diagnosis)
       implicit none
       double precision, intent(in) :: actual, expected_floor
       type(test_diagnosis_t) test_diagnosis
     end function
 
-    pure module function greater_than_integer(actual, expected_floor) result(test_diagnosis)
+    elemental module function greater_than_integer(actual, expected_floor) result(test_diagnosis)
       implicit none
       integer, intent(in) :: actual, expected_floor
       type(test_diagnosis_t) test_diagnosis
@@ -152,14 +152,14 @@ module julienne_test_diagnosis_m
 
   interface operator(.within.)
 
-    pure module function within_real(operands, tolerance) result(test_diagnosis)
+    elemental module function within_real(operands, tolerance) result(test_diagnosis)
       implicit none
       type(operands_t), intent(in) :: operands
       real, intent(in) :: tolerance
       type(test_diagnosis_t) test_diagnosis
     end function
    
-    pure module function within_double_precision(operands, tolerance) result(test_diagnosis)
+    elemental module function within_double_precision(operands, tolerance) result(test_diagnosis)
       implicit none
 #if HAVE_DERIVED_TYPE_KIND_PARAMETERS
       type(operands_t(double_precision)), intent(in) :: operands

--- a/src/julienne/julienne_test_diagnosis_m.F90
+++ b/src/julienne/julienne_test_diagnosis_m.F90
@@ -11,6 +11,7 @@ module julienne_test_diagnosis_m
   private
   public :: test_diagnosis_t
   public :: operator(.all.)
+  public :: operator(.and.)
   public :: operator(.approximates.)
   public :: operator(.within.)
   public :: operator(.equalsExpected.)
@@ -51,6 +52,16 @@ module julienne_test_diagnosis_m
     pure module function aggregate_diagnosis(diagnoses) result(diagnosis)
       implicit none
       type(test_diagnosis_t), intent(in) :: diagnoses(..)
+      type(test_diagnosis_t) diagnosis
+    end function
+
+  end interface
+
+  interface operator(.and.)
+     
+    elemental module function and(lhs, rhs) result(diagnosis)
+      implicit none
+      type(test_diagnosis_t), intent(in) :: lhs, rhs
       type(test_diagnosis_t) diagnosis
     end function
 

--- a/src/julienne/julienne_test_diagnosis_m.f90
+++ b/src/julienne/julienne_test_diagnosis_m.f90
@@ -7,6 +7,9 @@ module julienne_test_diagnosis_m
 
   private
   public :: test_diagnosis_t
+  public :: operator(.approximates.)
+  public :: operator(.within.)
+  public :: operator(.equalsExpected.)
 
   type test_diagnosis_t
     !! Encapsulate test outcome and diagnostic information
@@ -17,6 +20,57 @@ module julienne_test_diagnosis_m
     procedure test_passed
     procedure diagnostics_string
   end type
+
+  integer, parameter :: default_real = kind(1.), double_precision = kind(1D0)
+
+  type operands_t(k)
+    integer, kind :: k = default_real
+    real(k) actual, expected 
+  end type
+
+  interface operator(.approximates.)
+
+    pure module function approximates_real(actual, expected) result(operands)
+      implicit none
+      real, intent(in) :: actual, expected
+      type(operands_t) operands
+    end function
+
+    pure module function approximates_double_precision(actual, expected) result(operands)
+      implicit none
+      double precision, intent(in) :: actual, expected
+      type(operands_t(double_precision)) operands
+    end function
+
+  end interface
+
+  interface operator(.equalsExpected.)
+
+    pure module function equals_expected_integer(actual, expected) result(test_diagnosis)
+      implicit none
+      integer, intent(in) :: actual, expected
+      type(test_diagnosis_t) test_diagnosis
+    end function
+
+  end interface
+
+  interface operator(.within.)
+
+    pure module function within_real(operands, tolerance) result(test_diagnosis)
+      implicit none
+      type(operands_t), intent(in) :: operands
+      real, intent(in) :: tolerance
+      type(test_diagnosis_t) test_diagnosis
+    end function
+   
+    pure module function within_double_precision(operands, tolerance) result(test_diagnosis)
+      implicit none
+      type(operands_t(double_precision)), intent(in) :: operands
+      double precision, intent(in) :: tolerance
+      type(test_diagnosis_t) test_diagnosis
+    end function
+   
+  end interface
 
   interface test_diagnosis_t
 

--- a/src/julienne/julienne_test_diagnosis_s.F90
+++ b/src/julienne/julienne_test_diagnosis_s.F90
@@ -7,22 +7,71 @@ submodule(julienne_test_diagnosis_m) julienne_test_diagnosis_s
   use assert_m
   implicit none
 contains
-    module procedure construct_from_string_t
-      test_diagnosis%test_passed_ = test_passed
-      test_diagnosis%diagnostics_string_ = diagnostics_string
-    end procedure
 
-    module procedure construct_from_character
-      test_diagnosis%test_passed_ = test_passed
-      test_diagnosis%diagnostics_string_ = diagnostics_string
-    end procedure
+  module procedure approximates_real
+    operands = operands_t(actual, expected) 
+  end procedure
 
-    module procedure test_passed
-      passed = self%test_passed_
-    end procedure
+  module procedure approximates_double_precision
+    operands = operands_t(double_precision)(actual, expected) 
+  end procedure
 
-    module procedure diagnostics_string
-      call_assert(allocated(self%diagnostics_string_))
-      string_ = string_t(self%diagnostics_string_)
-    end procedure
+  module procedure equals_expected_integer
+
+    if (actual == expected) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed = .false. &
+        ,diagnostics_string = "expected " // string_t(expected) // "; actual value is " // string_t(actual) &
+      )
+    end if
+
+  end procedure
+
+  module procedure within_real
+
+    if (abs(operands%actual - operands%expected) < tolerance) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed=.false. &
+        ,diagnostics_string = "expected "              // string_t(operands%expected) &
+                           // "within a tolerance of " // string_t(tolerance)          &
+                           // "; actual value is "     // string_t(operands%actual)   &
+      )
+    end if
+
+  end procedure
+
+  module procedure within_double_precision
+
+    if (abs(operands%actual - operands%expected) < tolerance) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed=.false. &
+        ,diagnostics_string = "expected "              // string_t(operands%expected) &
+                           // "within a tolerance of " // string_t(tolerance)          &
+                           // "; actual value is "     // string_t(operands%actual)   &
+      )
+    end if
+
+  end procedure
+
+  module procedure construct_from_string_t
+    test_diagnosis%test_passed_ = test_passed
+    test_diagnosis%diagnostics_string_ = diagnostics_string
+  end procedure
+
+  module procedure construct_from_character
+    test_diagnosis%test_passed_ = test_passed
+    test_diagnosis%diagnostics_string_ = diagnostics_string
+  end procedure
+
+  module procedure test_passed
+    passed = self%test_passed_
+  end procedure
+
+  module procedure diagnostics_string
+    call_assert(allocated(self%diagnostics_string_))
+    string_ = string_t(self%diagnostics_string_)
+  end procedure
 end submodule julienne_test_diagnosis_s

--- a/src/julienne/julienne_test_diagnosis_s.F90
+++ b/src/julienne/julienne_test_diagnosis_s.F90
@@ -10,6 +10,10 @@ submodule(julienne_test_diagnosis_m) julienne_test_diagnosis_s
   implicit none
 contains
 
+  module procedure and
+     diagnosis = .all. ([lhs,rhs])
+  end procedure 
+
   module procedure aggregate_diagnosis
     character(len=*), parameter :: new_line_indent = new_line('') // "        "
     integer i

--- a/src/julienne/julienne_test_diagnosis_s.F90
+++ b/src/julienne/julienne_test_diagnosis_s.F90
@@ -69,6 +69,66 @@ contains
 
   end procedure
 
+  module procedure less_than_or_equal_to_integer
+
+    if (actual <= expected_max) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed = .false. &
+        ,diagnostics_string = "The value " // string_t(actual) // " was expected to be less than or equal to" // string_t(expected_max) &
+      )
+    end if
+
+  end procedure
+
+  module procedure greater_than_or_equal_to_integer
+
+    if (actual >= expected_min) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed = .false. &
+        ,diagnostics_string = "The value " // string_t(actual) // " was expected to be greater than or equal to " // string_t(expected_min) &
+      )
+    end if
+
+  end procedure
+
+  module procedure greater_than_real
+
+    if (actual > expected_floor) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed = .false. &
+        ,diagnostics_string = "The value " // string_t(actual) // " was expected to be greater than " // string_t(expected_floor) &
+      )
+    end if
+
+  end procedure
+
+  module procedure greater_than_double
+
+    if (actual > expected_floor) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed = .false. &
+        ,diagnostics_string = "The value " // string_t(actual) // " was expected to be greater than " // string_t(expected_floor) &
+      )
+    end if
+
+  end procedure
+
+  module procedure greater_than_integer
+
+    if (actual > expected_floor) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed = .false. &
+        ,diagnostics_string = "The value " // string_t(actual) // " was expected to be greater than " // string_t(expected_floor) &
+      )
+    end if
+
+  end procedure
+
   module procedure within_real
 
     if (abs(operands%actual - operands%expected) < tolerance) then

--- a/src/julienne/julienne_test_diagnosis_s.F90
+++ b/src/julienne/julienne_test_diagnosis_s.F90
@@ -33,6 +33,42 @@ contains
 
   end procedure
 
+  module procedure less_than_real
+
+    if (actual < expected_ceiling) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed = .false. &
+        ,diagnostics_string = "The value " // string_t(actual) // " was expected to be less than " // string_t(expected_ceiling) &
+      )
+    end if
+
+  end procedure
+
+  module procedure less_than_double
+
+    if (actual < expected_ceiling) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed = .false. &
+        ,diagnostics_string = "The value " // string_t(actual) // " was expected to be less than " // string_t(expected_ceiling) &
+      )
+    end if
+
+  end procedure
+
+  module procedure less_than_integer
+
+    if (actual < expected_ceiling) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed = .false. &
+        ,diagnostics_string = "The value " // string_t(actual) // " was expected to be less than " // string_t(expected_ceiling) &
+      )
+    end if
+
+  end procedure
+
   module procedure within_real
 
     if (abs(operands%actual - operands%expected) < tolerance) then

--- a/src/julienne/julienne_test_diagnosis_s.F90
+++ b/src/julienne/julienne_test_diagnosis_s.F90
@@ -13,7 +13,11 @@ contains
   end procedure
 
   module procedure approximates_double_precision
+#if HAVE_DERIVED_TYPE_KIND_PARAMETERS
     operands = operands_t(double_precision)(actual, expected) 
+#else
+    operands = double_precision_operands_t(actual, expected) 
+#endif
   end procedure
 
   module procedure equals_expected_integer

--- a/src/julienne/julienne_test_diagnosis_s.F90
+++ b/src/julienne/julienne_test_diagnosis_s.F90
@@ -2,6 +2,7 @@
 ! Terms of use are as specified in LICENSE.txt
 
 #include "assert_macros.h"
+#include "language-support.F90"
 
 submodule(julienne_test_diagnosis_m) julienne_test_diagnosis_s
   use assert_m

--- a/src/julienne_m.f90
+++ b/src/julienne_m.f90
@@ -13,6 +13,7 @@ module julienne_m
   use julienne_test_diagnosis_m, only : &
      test_diagnosis_t &
     ,operator(.all.) &
+    ,operator(.and.) &
     ,operator(.approximates.) &
     ,operator(.within.) &
     ,operator(.equalsExpected.) &

--- a/src/julienne_m.f90
+++ b/src/julienne_m.f90
@@ -10,7 +10,7 @@ module julienne_m
   use julienne_string_m, only : string_t, operator(.cat.), operator(.csv.), operator(.sv.)
   use julienne_test_m, only : test_t, test_description_substring
   use julienne_test_description_m, only : test_description_t, diagnosis_function_i
-  use julienne_test_diagnosis_m, only : test_diagnosis_t, operator(.approximates.), operator(.within.), operator(.equalsExpected.)
+  use julienne_test_diagnosis_m, only : test_diagnosis_t, operator(.approximates.), operator(.within.), operator(.equalsExpected.), operator(.lessThan.)
   use julienne_test_result_m, only : test_result_t
   use julienne_vector_test_description_m, only : vector_test_description_t, vector_diagnosis_function_i
   implicit none

--- a/src/julienne_m.f90
+++ b/src/julienne_m.f90
@@ -10,7 +10,7 @@ module julienne_m
   use julienne_string_m, only : string_t, operator(.cat.), operator(.csv.), operator(.sv.)
   use julienne_test_m, only : test_t, test_description_substring
   use julienne_test_description_m, only : test_description_t, diagnosis_function_i
-  use julienne_test_diagnosis_m, only : test_diagnosis_t
+  use julienne_test_diagnosis_m, only : test_diagnosis_t, operator(.approximates.), operator(.within.), operator(.equalsExpected.)
   use julienne_test_result_m, only : test_result_t
   use julienne_vector_test_description_m, only : vector_test_description_t, vector_diagnosis_function_i
   implicit none

--- a/src/julienne_m.f90
+++ b/src/julienne_m.f90
@@ -12,6 +12,7 @@ module julienne_m
   use julienne_test_description_m, only : test_description_t, diagnosis_function_i
   use julienne_test_diagnosis_m, only : &
      test_diagnosis_t &
+    ,operator(.all.) &
     ,operator(.approximates.) &
     ,operator(.within.) &
     ,operator(.equalsExpected.) &

--- a/src/julienne_m.f90
+++ b/src/julienne_m.f90
@@ -10,7 +10,15 @@ module julienne_m
   use julienne_string_m, only : string_t, operator(.cat.), operator(.csv.), operator(.sv.)
   use julienne_test_m, only : test_t, test_description_substring
   use julienne_test_description_m, only : test_description_t, diagnosis_function_i
-  use julienne_test_diagnosis_m, only : test_diagnosis_t, operator(.approximates.), operator(.within.), operator(.equalsExpected.), operator(.lessThan.)
+  use julienne_test_diagnosis_m, only : &
+     test_diagnosis_t &
+    ,operator(.approximates.) &
+    ,operator(.within.) &
+    ,operator(.equalsExpected.) &
+    ,operator(.lessThan.) &
+    ,operator(.lessThanOrEqualTo.) &
+    ,operator(.greaterThan.) &
+    ,operator(.greaterThanOrEqualTo.)
   use julienne_test_result_m, only : test_result_t
   use julienne_vector_test_description_m, only : vector_test_description_t, vector_diagnosis_function_i
   implicit none

--- a/test/main.F90
+++ b/test/main.F90
@@ -16,6 +16,7 @@ program main
   use string_test_m                  ,only :                  string_test_t
   use test_result_test_m             ,only :             test_result_test_t
   use test_description_test_m        ,only :        test_description_test_t
+  use test_diagnosis_test_m          ,only :          test_diagnosis_test_t
   use vector_test_description_test_m ,only : vector_test_description_test_t
   implicit none
 
@@ -25,6 +26,7 @@ program main
   type(string_test_t) string_test
   type(test_result_test_t) test_result_test
   type(test_description_test_t) test_description_test
+  type(test_diagnosis_test_t) test_diagnosis_test
   type(vector_test_description_test_t) vector_test_description_test
 
   type(command_line_t) command_line
@@ -48,6 +50,7 @@ program main
   call string_test%report(passes, tests, skips)
   call test_result_test%report(passes, tests, skips)
   call test_description_test%report(passes, tests, skips)
+  call test_diagnosis_test%report(passes, tests, skips)
   call vector_test_description_test%report(passes,tests, skips)
 
   if (.not. GitHub_CI())  then

--- a/test/test_diagnosis_test_m.F90
+++ b/test/test_diagnosis_test_m.F90
@@ -48,8 +48,8 @@ contains
     ] )
 #else
      ! Work around missing Fortran 2008 feature: associating a procedure actual argument with a procedure pointer dummy argument:
-     type(test_diagnosis_t), allocatable :: descriptions(:)
-     procedure(diagnosis_function_i), pointer :: check_real_approximates_ptr, check_double_approximates, check_integer_equals
+     type(test_description_t), allocatable :: descriptions(:)
+     procedure(diagnosis_function_i), pointer :: check_real_approximates_ptr, check_double_approximates_ptr, check_integer_equals_ptr
      check_real_approximates_ptr => check_real_approximates
      check_double_approximates_ptr => check_double_approximates
 
@@ -73,7 +73,7 @@ contains
     block
       logical substring_in_subject
       logical, allocatable :: substring_in_test_diagnosis(:)
-      type(test_diagnosis_t), allocatable :: matching_descriptions(:)
+      type(test_description_t), allocatable :: matching_descriptions(:)
 
       substring_in_subject = index(subject(), test_description_substring) /= 0
       substring_in_test_diagnosis = descriptions%contains_text(test_description_substring)

--- a/test/test_diagnosis_test_m.F90
+++ b/test/test_diagnosis_test_m.F90
@@ -42,22 +42,22 @@ contains
 
 #if HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
     associate(descriptions => [ &
-       test_description_t("contruction from a real expression of the form 'x .approximates. y .within. tolerance'", check_real_approximates) &
-      ,test_description_t("contruction from a double precision expression of the form 'x .approximates. y .within. tolerance'", check_double_approximates) &
-      ,test_description_t("contruction from an integer expression of the form 'i .equalsExpected. j", check_integer_equals) &
+       test_description_t("contruction from a real expression of the form 'x .approximates. y .within. tolerance'", check_approximates_real) &
+      ,test_description_t("contruction from a double precision expression of the form 'x .approximates. y .within. tolerance'", check_approximatees_double) &
+      ,test_description_t("contruction from an integer expression of the form 'i .equalsExpected. j", check_equals_integer) &
     ] )
 #else
      ! Work around missing Fortran 2008 feature: associating a procedure actual argument with a procedure pointer dummy argument:
      type(test_description_t), allocatable :: descriptions(:)
-     procedure(diagnosis_function_i), pointer :: check_real_approximates_ptr, check_double_approximates_ptr, check_integer_equals_ptr
-     check_real_approximates_ptr => check_real_approximates
-     check_double_approximates_ptr => check_double_approximates
-     check_integer_equals_ptr => check_integer_equals
+     procedure(diagnosis_function_i), pointer :: check_approximates_real_ptr, check_approximatees_double_ptr, check_equals_integer_ptr
+     check_approximates_real_ptr => check_approximates_real
+     check_approximatees_double_ptr => check_approximatees_double
+     check_equals_integer_ptr => check_equals_integer
 
      descriptions = [ &
-       test_description_t("contruction from a real expression of the form `x .approximates. y .within. tolerance`", check_real_approximates_ptr) &
-      ,test_description_t("contruction from a double-precision expression of the form `x .approximates. y .within. tolerance`", check_double_approximates_ptr) &
-      ,test_description_t("contruction from an integer expression of the form `i .equalsExpected. j`", check_integer_equals_ptr) &
+       test_description_t("contruction from a real expression of the form `x .approximates. y .within. tolerance`", check_approximates_real_ptr) &
+      ,test_description_t("contruction from a double-precision expression of the form `x .approximates. y .within. tolerance`", check_approximatees_double_ptr) &
+      ,test_description_t("contruction from an integer expression of the form `i .equalsExpected. j`", check_equals_integer_ptr) &
      ]
 #endif
 
@@ -85,19 +85,19 @@ contains
 
   end function
 
-  function check_real_approximates() result(test_diagnosis)
+  function check_approximates_real() result(test_diagnosis)
     type(test_diagnosis_t) test_diagnosis
     real, parameter :: expected_value = 1., tolerance = 1.E-08
     test_diagnosis = 1. .approximates. expected_value .within. tolerance
   end function
 
-  function check_double_approximates() result(test_diagnosis)
+  function check_approximatees_double() result(test_diagnosis)
     type(test_diagnosis_t) test_diagnosis
     double precision, parameter :: expected_value = 1D0, tolerance = 1D-16
     test_diagnosis = 1D0 .approximates. expected_value .within. tolerance
   end function
 
-  function check_integer_equals() result(test_diagnosis)
+  function check_equals_integer() result(test_diagnosis)
     type(test_diagnosis_t) test_diagnosis
     integer, parameter :: expected_value = 1
     test_diagnosis = 1 .equalsExpected. expected_value

--- a/test/test_diagnosis_test_m.F90
+++ b/test/test_diagnosis_test_m.F90
@@ -103,7 +103,7 @@ contains
       ,test_description_t("contruction from a integer expression of the form 'i .greaterThanOrEqualTo. j") & ! skip check_greater_than_or_equal_to_integer_ptr
       ,test_description_t("contruction from a scalar test_diagnostics_t expression with operands like 'i .equalsExpected. j'"  ) & ! skip check_and_with_scalar_operands_ptr
       ,test_description_t("contruction from test_diagnostics_t vector expressions with operands like 'i .equalsExpected. [j,k]'") & ! skip check_and_with_vector_operands_ptr
-  check_and_with_vector_operands
+      ,test_description_t("contruction from vector test_diagnostics_t expressions with operands like 'i .equalsExpected. [j,k]'", check_and_with_vector_operands_ptr) &
      ]
 #endif
 

--- a/test/test_diagnosis_test_m.F90
+++ b/test/test_diagnosis_test_m.F90
@@ -52,11 +52,12 @@ contains
      procedure(diagnosis_function_i), pointer :: check_real_approximates_ptr, check_double_approximates_ptr, check_integer_equals_ptr
      check_real_approximates_ptr => check_real_approximates
      check_double_approximates_ptr => check_double_approximates
+     check_integer_equals_ptr => check_integer_equals
 
      descriptions = [ &
-       test_description_t("contruction from a real expression of the form 'x .approximates. y .within. tolerance'", check_real_approximates_ptr) &
-      ,test_description_t("contruction from a double-precision expression of the form 'x .approximates. y .within. tolerance'", check_double_approximates_ptr) &
-      ,test_description_t("contruction from an integer expression of the form 'i .equalsExpected. j", check_integer_equals_ptr) &
+       test_description_t("contruction from a real expression of the form `x .approximates. y .within. tolerance`", check_real_approximates_ptr) &
+      ,test_description_t("contruction from a double-precision expression of the form `x .approximates. y .within. tolerance`", check_double_approximates_ptr) &
+      ,test_description_t("contruction from an integer expression of the form `i .equalsExpected. j`", check_integer_equals_ptr) &
      ]
 #endif
 

--- a/test/test_diagnosis_test_m.F90
+++ b/test/test_diagnosis_test_m.F90
@@ -48,19 +48,19 @@ contains
 
 #if HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
     associate(descriptions => [ &
-       test_description_t("contruction from a real expression of the form 'x .approximates. y .within. tolerance'", check_approximates_real) &
-      ,test_description_t("contruction from a double precision expression of the form 'x .approximates. y .within. tolerance'", check_approximates_double) &
-      ,test_description_t("contruction from an integer expression of the form 'i .equalsExpected. j", check_equals_integer) &
-      ,test_description_t("contruction from a real expression of the form 'x .lessThan. y", check_less_than_real) &
-      ,test_description_t("contruction from a double precision expression of the form 'x .lessThan. y", check_less_than_double) &
-      ,test_description_t("contruction from a integer expression of the form 'i .lessThan. j", check_less_than_integer) &
-      ,test_description_t("contruction from a real expression of the form 'x .greaterThan. y", check_greater_than_real) &
-      ,test_description_t("contruction from a double precision expression of the form 'x .greaterThan. y", check_greater_than_double) &
-      ,test_description_t("contruction from a integer expression of the form 'i .greaterThan. j", check_greater_than_integer) &
-      ,test_description_t("contruction from a integer expression of the form '[i,j] .lessThanOrEqualTo. k", check_less_than_or_equal_to_integer) &
-      ,test_description_t("contruction from a integer expression of the form '[i,j] .greaterThanOrEqualTo. k", check_greater_than_or_equal_to_integer) &
-      ,test_description_t("contruction from a scalar test_diagnostics_t expression of the form 't .and. u'", check_and_with_scalar_operands) &
-      ,test_description_t("contruction from vector test_diagnostics_t expressions with operands like 'i .equalsExpected. [j,k]'", check_and_with_vector_operands) &
+       test_description_t("construction from a real expression of the form 'x .approximates. y .within. tolerance'", check_approximates_real) &
+      ,test_description_t("construction from a double precision expression of the form 'x .approximates. y .within. tolerance'", check_approximates_double) &
+      ,test_description_t("construction from an integer expression of the form 'i .equalsExpected. j", check_equals_integer) &
+      ,test_description_t("construction from a real expression of the form 'x .lessThan. y", check_less_than_real) &
+      ,test_description_t("construction from a double precision expression of the form 'x .lessThan. y", check_less_than_double) &
+      ,test_description_t("construction from a integer expression of the form 'i .lessThan. j", check_less_than_integer) &
+      ,test_description_t("construction from a real expression of the form 'x .greaterThan. y", check_greater_than_real) &
+      ,test_description_t("construction from a double precision expression of the form 'x .greaterThan. y", check_greater_than_double) &
+      ,test_description_t("construction from a integer expression of the form 'i .greaterThan. j", check_greater_than_integer) &
+      ,test_description_t("construction from a integer expression of the form '[i,j] .lessThanOrEqualTo. k", check_less_than_or_equal_to_integer) &
+      ,test_description_t("construction from a integer expression of the form '[i,j] .greaterThanOrEqualTo. k", check_greater_than_or_equal_to_integer) &
+      ,test_description_t("construction from a scalar test_diagnostics_t expression of the form 't .and. u'", check_and_with_scalar_operands) &
+      ,test_description_t("construction from vector test_diagnostics_t expressions with operands like 'i .equalsExpected. [j,k]'", check_and_with_vector_operands) &
     ] )
 #else
      ! Work around missing Fortran 2008 feature: associating a procedure actual argument with a procedure pointer dummy argument:
@@ -90,20 +90,20 @@ contains
      check_and_with_vector_operands_ptr         => check_and_with_vector_operands
 
      descriptions = [ &
-       test_description_t("contruction from a real expression of the form `x .approximates. y .within. tolerance`"            , check_approximates_real_ptr) &
-      ,test_description_t("contruction from a double-precision expression of the form `x .approximates. y .within. tolerance`", check_approximates_double_ptr) &
-      ,test_description_t("contruction from an integer expression of the form `i .equalsExpected. j`"                         , check_equals_integer_ptr) &
-      ,test_description_t("contruction from a real expression of the form 'x .lessThan. y"                                    , check_less_than_real_ptr) &
-      ,test_description_t("contruction from a double precision expression of the form 'x .lessThan. y"                        , check_less_than_double_ptr) &
-      ,test_description_t("contruction from a integer expression of the form 'i .lessThan. j"                                 , check_less_than_integer_ptr) &
-      ,test_description_t("contruction from a integer expression of the form 'i .lessThanOrEqualTo. j"   ) & ! skip check_less_than_or_equal_to_integer_ptr
-      ,test_description_t("contruction from a real expression of the form 'x .greaterThan. y"                                 , check_greater_than_real_ptr) &
-      ,test_description_t("contruction from a double precision expression of the form 'x .greaterThan. y"                     , check_greater_than_double_ptr) &
-      ,test_description_t("contruction from a integer expression of the form 'i .greaterThan. j"                              , check_greater_than_integer_ptr) &
-      ,test_description_t("contruction from a integer expression of the form 'i .greaterThanOrEqualTo. j") & ! skip check_greater_than_or_equal_to_integer_ptr
-      ,test_description_t("contruction from a scalar test_diagnostics_t expression with operands like 'i .equalsExpected. j'"  ) & ! skip check_and_with_scalar_operands_ptr
-      ,test_description_t("contruction from test_diagnostics_t vector expressions with operands like 'i .equalsExpected. [j,k]'") & ! skip check_and_with_vector_operands_ptr
-      ,test_description_t("contruction from vector test_diagnostics_t expressions with operands like 'i .equalsExpected. [j,k]'") & !, check_and_with_vector_operands_ptr) &
+       test_description_t("construction from a real expression of the form `x .approximates. y .within. tolerance`"            , check_approximates_real_ptr) &
+      ,test_description_t("construction from a double-precision expression of the form `x .approximates. y .within. tolerance`", check_approximates_double_ptr) &
+      ,test_description_t("construction from an integer expression of the form `i .equalsExpected. j`"                         , check_equals_integer_ptr) &
+      ,test_description_t("construction from a real expression of the form 'x .lessThan. y"                                    , check_less_than_real_ptr) &
+      ,test_description_t("construction from a double precision expression of the form 'x .lessThan. y"                        , check_less_than_double_ptr) &
+      ,test_description_t("construction from a integer expression of the form 'i .lessThan. j"                                 , check_less_than_integer_ptr) &
+      ,test_description_t("construction from a integer expression of the form 'i .lessThanOrEqualTo. j"   ) & ! skip check_less_than_or_equal_to_integer_ptr
+      ,test_description_t("construction from a real expression of the form 'x .greaterThan. y"                                 , check_greater_than_real_ptr) &
+      ,test_description_t("construction from a double precision expression of the form 'x .greaterThan. y"                     , check_greater_than_double_ptr) &
+      ,test_description_t("construction from a integer expression of the form 'i .greaterThan. j"                              , check_greater_than_integer_ptr) &
+      ,test_description_t("construction from a integer expression of the form 'i .greaterThanOrEqualTo. j") & ! skip check_greater_than_or_equal_to_integer_ptr
+      ,test_description_t("construction from a scalar test_diagnostics_t expression with operands like 'i .equalsExpected. j'"  ) & ! skip check_and_with_scalar_operands_ptr
+      ,test_description_t("construction from test_diagnostics_t vector expressions with operands like 'i .equalsExpected. [j,k]'") & ! skip check_and_with_vector_operands_ptr
+      ,test_description_t("construction from vector test_diagnostics_t expressions with operands like 'i .equalsExpected. [j,k]'") & !, check_and_with_vector_operands_ptr) &
      ]
 #endif
 

--- a/test/test_diagnosis_test_m.F90
+++ b/test/test_diagnosis_test_m.F90
@@ -16,6 +16,7 @@ module test_diagnosis_test_m
 #if ! HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
     ,diagnosis_function_i &
 #endif
+    ,operator(.all.) &
     ,operator(.equalsExpected.) &
     ,operator(.approximates.) &
     ,operator(.within.) &
@@ -171,13 +172,13 @@ contains
   function check_less_than_or_equal_to_integer() result(test_diagnosis)
     type(test_diagnosis_t) test_diagnosis
     integer, parameter :: expected_max = 1
-    test_diagnosis = 1 .lessThanOrEqualTo. expected_max
+    test_diagnosis = .all. ([0,1] .lessThanOrEqualTo. expected_max)
   end function
 
   function check_greater_than_or_equal_to_integer() result(test_diagnosis)
     type(test_diagnosis_t) test_diagnosis
     integer, parameter :: expected_min = 1
-    test_diagnosis = 1 .greaterThanOrEqualTo. expected_min
+    test_diagnosis = .all. ([1,2] .greaterThanOrEqualTo. expected_min)
   end function
 
 end module test_diagnosis_test_m

--- a/test/test_diagnosis_test_m.F90
+++ b/test/test_diagnosis_test_m.F90
@@ -172,7 +172,7 @@ contains
   function check_greater_than_integer() result(test_diagnosis)
     type(test_diagnosis_t) test_diagnosis
     integer, parameter :: expected_floor = 1
-    test_diagnosis = 2 .greaterThan. expected_floor
+    test_diagnosis = (2 .greaterThan. expected_floor)
   end function
 
   function check_less_than_or_equal_to_integer() result(test_diagnosis)

--- a/test/test_diagnosis_test_m.F90
+++ b/test/test_diagnosis_test_m.F90
@@ -103,7 +103,7 @@ contains
       ,test_description_t("contruction from a integer expression of the form 'i .greaterThanOrEqualTo. j") & ! skip check_greater_than_or_equal_to_integer_ptr
       ,test_description_t("contruction from a scalar test_diagnostics_t expression with operands like 'i .equalsExpected. j'"  ) & ! skip check_and_with_scalar_operands_ptr
       ,test_description_t("contruction from test_diagnostics_t vector expressions with operands like 'i .equalsExpected. [j,k]'") & ! skip check_and_with_vector_operands_ptr
-      ,test_description_t("contruction from vector test_diagnostics_t expressions with operands like 'i .equalsExpected. [j,k]'", check_and_with_vector_operands_ptr) &
+      ,test_description_t("contruction from vector test_diagnostics_t expressions with operands like 'i .equalsExpected. [j,k]'") & !, check_and_with_vector_operands_ptr) &
      ]
 #endif
 

--- a/test/test_diagnosis_test_m.F90
+++ b/test/test_diagnosis_test_m.F90
@@ -1,0 +1,105 @@
+! Copyright (c) 2024, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
+
+#include "language-support.F90"
+
+module test_diagnosis_test_m
+  !! Verify test_diagnosis_t object behavior
+
+  use julienne_m, only : & 
+     string_t &
+    ,test_t &
+    ,test_description_t &
+    ,test_description_substring &
+    ,test_diagnosis_t &
+    ,test_result_t &
+#if ! HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
+    ,diagnosis_function_i &
+#endif
+    ,operator(.equalsExpected.) &
+    ,operator(.approximates.) &
+    ,operator(.within.)
+  implicit none
+
+  private
+  public :: test_diagnosis_test_t
+
+  type, extends(test_t) :: test_diagnosis_test_t
+  contains
+    procedure, nopass :: subject
+    procedure, nopass :: results
+  end type
+
+contains
+
+  pure function subject() result(specimen)
+    character(len=:), allocatable :: specimen
+    specimen = "The test_diagnosis_t type" 
+  end function
+
+  function results() result(test_results)
+    type(test_result_t), allocatable :: test_results(:)
+
+#if HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
+    associate(descriptions => [ &
+       test_description_t("contruction from a real expression of the form 'x .approximates. y .within. tolerance'", check_real_approximates) &
+      ,test_description_t("contruction from a double precision expression of the form 'x .approximates. y .within. tolerance'", check_double_approximates) &
+      ,test_description_t("contruction from an integer expression of the form 'i .equalsExpected. j", check_integer_equals) &
+    ] )
+#else
+     ! Work around missing Fortran 2008 feature: associating a procedure actual argument with a procedure pointer dummy argument:
+     type(test_diagnosis_t), allocatable :: descriptions(:)
+     procedure(diagnosis_function_i), pointer :: check_real_approximates_ptr, check_double_approximates, check_integer_equals
+     check_real_approximates_ptr => check_real_approximates
+     check_double_approximates_ptr => check_double_approximates
+
+     descriptions = [ &
+       test_description_t("contruction from a real expression of the form 'x .approximates. y .within. tolerance'", check_real_approximates_ptr) &
+      ,test_description_t("contruction from a double-precision expression of the form 'x .approximates. y .within. tolerance'", check_double_approximates_ptr) &
+      ,test_description_t("contruction from an integer expression of the form 'i .equalsExpected. j", check_integer_equals_ptr) &
+     ]
+#endif
+
+#ifndef __GFORTRAN__
+      associate(substring_in_subject => index(subject(), test_description_substring) /= 0)
+        associate(substring_in_test_diagnosis => descriptions%contains_text(test_description_substring))
+          associate(matching_descriptions => pack(descriptions, substring_in_subject .or. substring_in_test_diagnosis))
+            test_results = matching_descriptions%run()
+          end associate
+        end associate
+      end associate
+    end associate
+#else
+    block
+      logical substring_in_subject
+      logical, allocatable :: substring_in_test_diagnosis(:)
+      type(test_diagnosis_t), allocatable :: matching_descriptions(:)
+
+      substring_in_subject = index(subject(), test_description_substring) /= 0
+      substring_in_test_diagnosis = descriptions%contains_text(test_description_substring)
+      matching_descriptions = pack(descriptions, substring_in_subject .or. substring_in_test_diagnosis)
+      test_results = matching_descriptions%run()
+    end block
+#endif
+
+  end function
+
+  function check_real_approximates() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    real, parameter :: expected_value = 1., tolerance = 1.E-08
+    test_diagnosis = 1. .approximates. expected_value .within. tolerance
+  end function
+
+  function check_double_approximates() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    double precision, parameter :: expected_value = 1D0, tolerance = 1D-16
+    test_diagnosis = 1D0 .approximates. expected_value .within. tolerance
+  end function
+
+  function check_integer_equals() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    integer, parameter :: expected_value = 1
+    test_diagnosis = 1 .equalsExpected. expected_value
+  end function
+
+end module test_diagnosis_test_m

--- a/test/test_diagnosis_test_m.F90
+++ b/test/test_diagnosis_test_m.F90
@@ -18,7 +18,8 @@ module test_diagnosis_test_m
 #endif
     ,operator(.equalsExpected.) &
     ,operator(.approximates.) &
-    ,operator(.within.)
+    ,operator(.within.) &
+    ,operator(.lessThan.)
   implicit none
 
   private
@@ -45,19 +46,29 @@ contains
        test_description_t("contruction from a real expression of the form 'x .approximates. y .within. tolerance'", check_approximates_real) &
       ,test_description_t("contruction from a double precision expression of the form 'x .approximates. y .within. tolerance'", check_approximatees_double) &
       ,test_description_t("contruction from an integer expression of the form 'i .equalsExpected. j", check_equals_integer) &
+      ,test_description_t("contruction from a real expression of the form 'x .lessThan. y", check_less_than_real) &
+      ,test_description_t("contruction from a double precision expression of the form 'x .lessThan. y", check_less_than_double) &
+      ,test_description_t("contruction from a intenger expression of the form 'i .lessThan. j", check_less_than_integer) &
     ] )
 #else
      ! Work around missing Fortran 2008 feature: associating a procedure actual argument with a procedure pointer dummy argument:
      type(test_description_t), allocatable :: descriptions(:)
-     procedure(diagnosis_function_i), pointer :: check_approximates_real_ptr, check_approximatees_double_ptr, check_equals_integer_ptr
+     procedure(diagnosis_function_i), pointer :: check_approximates_real_ptr, check_approximatees_double_ptr, check_equals_integer_ptr, check_less_than_real &
+       check_less_than_double, check_less_than_integer
      check_approximates_real_ptr => check_approximates_real
      check_approximatees_double_ptr => check_approximatees_double
      check_equals_integer_ptr => check_equals_integer
+     check_less_than_real_ptr => check_less_than_real
+     check_less_than_double_ptr => check_less_than_double
+     check_less_than_integer_ptr => check_less_than_integer
 
      descriptions = [ &
        test_description_t("contruction from a real expression of the form `x .approximates. y .within. tolerance`", check_approximates_real_ptr) &
       ,test_description_t("contruction from a double-precision expression of the form `x .approximates. y .within. tolerance`", check_approximatees_double_ptr) &
       ,test_description_t("contruction from an integer expression of the form `i .equalsExpected. j`", check_equals_integer_ptr) &
+      ,test_description_t("contruction from a real expression of the form 'x .lessThan. y", check_less_than_real_ptr) &
+      ,test_description_t("contruction from a double precision expression of the form 'x .lessThan. y", check_less_than_double_ptr) &
+      ,test_description_t("contruction from a integer expression of the form 'i .lessThan. j", check_less_than_integer_ptr) &
      ]
 #endif
 
@@ -101,6 +112,24 @@ contains
     type(test_diagnosis_t) test_diagnosis
     integer, parameter :: expected_value = 1
     test_diagnosis = 1 .equalsExpected. expected_value
+  end function
+
+  function check_less_than_real() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    real, parameter :: expected_ceiling = 1.
+    test_diagnosis = 0. .lessThan. expected_ceiling
+  end function
+
+  function check_less_than_double() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    double precision, parameter :: expected_ceiling = 1D0
+    test_diagnosis = 0D0 .lessThan. expected_ceiling
+  end function
+
+  function check_less_than_integer() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    integer, parameter :: expected_ceiling = 1
+    test_diagnosis = 0 .lessThan. expected_ceiling
   end function
 
 end module test_diagnosis_test_m

--- a/test/test_diagnosis_test_m.F90
+++ b/test/test_diagnosis_test_m.F90
@@ -19,7 +19,10 @@ module test_diagnosis_test_m
     ,operator(.equalsExpected.) &
     ,operator(.approximates.) &
     ,operator(.within.) &
-    ,operator(.lessThan.)
+    ,operator(.lessThan.) &
+    ,operator(.lessThanOrEqualTo.) &
+    ,operator(.greaterThan.) &
+    ,operator(.greaterThanOrEqualTo.)
   implicit none
 
   private
@@ -48,19 +51,29 @@ contains
       ,test_description_t("contruction from an integer expression of the form 'i .equalsExpected. j", check_equals_integer) &
       ,test_description_t("contruction from a real expression of the form 'x .lessThan. y", check_less_than_real) &
       ,test_description_t("contruction from a double precision expression of the form 'x .lessThan. y", check_less_than_double) &
-      ,test_description_t("contruction from a intenger expression of the form 'i .lessThan. j", check_less_than_integer) &
+      ,test_description_t("contruction from a integer expression of the form 'i .lessThan. j", check_less_than_integer) &
+      ,test_description_t("contruction from a real expression of the form 'x .greaterThan. y", check_greater_than_real) &
+      ,test_description_t("contruction from a double precision expression of the form 'x .greaterThan. y", check_greater_than_double) &
+      ,test_description_t("contruction from a integer expression of the form 'i .greaterThan. j", check_greater_than_integer) &
+      ,test_description_t("contruction from a integer expression of the form 'i .lessThanOrEqualTo. j", check_less_than_or_equal_to_integer) &
+      ,test_description_t("contruction from a integer expression of the form 'i .greaterThanOrEqualTo. j", check_greater_than_or_equal_to_integer) &
     ] )
 #else
      ! Work around missing Fortran 2008 feature: associating a procedure actual argument with a procedure pointer dummy argument:
      type(test_description_t), allocatable :: descriptions(:)
-     procedure(diagnosis_function_i), pointer :: check_approximates_real_ptr, check_approximatees_double_ptr, check_equals_integer_ptr, check_less_than_real &
-       check_less_than_double, check_less_than_integer
+     procedure(diagnosis_function_i), pointer :: check_approximates_real_ptr, check_approximatees_double_ptr, check_equals_integer_ptr &
+       ,check_less_than_real, check_less_than_double, check_less_than_integer_ptr &
+       ,check_greater_than_real_ptr, check_greater_than_double, check_greater_than_integer_ptr &
+       ,check_less_than_or_equal_to_integer_ptr
+       
      check_approximates_real_ptr => check_approximates_real
      check_approximatees_double_ptr => check_approximatees_double
      check_equals_integer_ptr => check_equals_integer
      check_less_than_real_ptr => check_less_than_real
      check_less_than_double_ptr => check_less_than_double
      check_less_than_integer_ptr => check_less_than_integer
+     check_less_than_or_equal_to_integer_ptr => check_less_than_or_equal_to_integer
+     check_greater_than_or_equal_to_integer_ptr => check_greater_than_or_equal_to_integer
 
      descriptions = [ &
        test_description_t("contruction from a real expression of the form `x .approximates. y .within. tolerance`", check_approximates_real_ptr) &
@@ -69,6 +82,11 @@ contains
       ,test_description_t("contruction from a real expression of the form 'x .lessThan. y", check_less_than_real_ptr) &
       ,test_description_t("contruction from a double precision expression of the form 'x .lessThan. y", check_less_than_double_ptr) &
       ,test_description_t("contruction from a integer expression of the form 'i .lessThan. j", check_less_than_integer_ptr) &
+      ,test_description_t("contruction from a real expression of the form 'x .greaterThan. y", check_greater_than_real_ptr) &
+      ,test_description_t("contruction from a double precision expression of the form 'x .greaterThan. y", check_greater_than_double_ptr) &
+      ,test_description_t("contruction from a integer expression of the form 'i .greaterThan. j", check_greater_than_integer_ptr) &
+      ,test_description_t("contruction from a integer expression of the form 'i .lessThanOrEqualTo. j", check_less_than_or_equal_to_integer_ptr) &
+      ,test_description_t("contruction from a integer expression of the form 'i .greaterThanOrEqualTo. j", check_greater_than_or_equal_to_integer_ptr) &
      ]
 #endif
 
@@ -130,6 +148,36 @@ contains
     type(test_diagnosis_t) test_diagnosis
     integer, parameter :: expected_ceiling = 1
     test_diagnosis = 0 .lessThan. expected_ceiling
+  end function
+
+  function check_greater_than_real() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    real, parameter :: expected_floor = 1.
+    test_diagnosis = 2. .greaterThan. expected_floor
+  end function
+
+  function check_greater_than_double() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    double precision, parameter :: expected_floor = 1D0
+    test_diagnosis = 2D0 .greaterThan. expected_floor
+  end function
+
+  function check_greater_than_integer() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    integer, parameter :: expected_floor = 1
+    test_diagnosis = 2 .greaterThan. expected_floor
+  end function
+
+  function check_less_than_or_equal_to_integer() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    integer, parameter :: expected_max = 1
+    test_diagnosis = 1 .lessThanOrEqualTo. expected_max
+  end function
+
+  function check_greater_than_or_equal_to_integer() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    integer, parameter :: expected_min = 1
+    test_diagnosis = 1 .greaterThanOrEqualTo. expected_min
   end function
 
 end module test_diagnosis_test_m

--- a/test/test_diagnosis_test_m.F90
+++ b/test/test_diagnosis_test_m.F90
@@ -56,8 +56,8 @@ contains
       ,test_description_t("contruction from a real expression of the form 'x .greaterThan. y", check_greater_than_real) &
       ,test_description_t("contruction from a double precision expression of the form 'x .greaterThan. y", check_greater_than_double) &
       ,test_description_t("contruction from a integer expression of the form 'i .greaterThan. j", check_greater_than_integer) &
-      ,test_description_t("contruction from a integer expression of the form 'i .lessThanOrEqualTo. j", check_less_than_or_equal_to_integer) &
-      ,test_description_t("contruction from a integer expression of the form 'i .greaterThanOrEqualTo. j", check_greater_than_or_equal_to_integer) &
+      ,test_description_t("contruction from a integer expression of the form '[i,j] .lessThanOrEqualTo. k", check_less_than_or_equal_to_integer) &
+      ,test_description_t("contruction from a integer expression of the form '[i,j] .greaterThanOrEqualTo. k", check_greater_than_or_equal_to_integer) &
     ] )
 #else
      ! Work around missing Fortran 2008 feature: associating a procedure actual argument with a procedure pointer dummy argument:

--- a/test/test_diagnosis_test_m.F90
+++ b/test/test_diagnosis_test_m.F90
@@ -48,7 +48,7 @@ contains
 #if HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
     associate(descriptions => [ &
        test_description_t("contruction from a real expression of the form 'x .approximates. y .within. tolerance'", check_approximates_real) &
-      ,test_description_t("contruction from a double precision expression of the form 'x .approximates. y .within. tolerance'", check_approximatees_double) &
+      ,test_description_t("contruction from a double precision expression of the form 'x .approximates. y .within. tolerance'", check_approximates_double) &
       ,test_description_t("contruction from an integer expression of the form 'i .equalsExpected. j", check_equals_integer) &
       ,test_description_t("contruction from a real expression of the form 'x .lessThan. y", check_less_than_real) &
       ,test_description_t("contruction from a double precision expression of the form 'x .lessThan. y", check_less_than_double) &
@@ -62,32 +62,38 @@ contains
 #else
      ! Work around missing Fortran 2008 feature: associating a procedure actual argument with a procedure pointer dummy argument:
      type(test_description_t), allocatable :: descriptions(:)
-     procedure(diagnosis_function_i), pointer :: check_approximates_real_ptr, check_approximatees_double_ptr, check_equals_integer_ptr &
-       ,check_less_than_real, check_less_than_double, check_less_than_integer_ptr &
-       ,check_greater_than_real_ptr, check_greater_than_double, check_greater_than_integer_ptr &
-       ,check_less_than_or_equal_to_integer_ptr
+     procedure(diagnosis_function_i), pointer :: &
+        check_approximates_real_ptr &
+       ,check_approximates_double_ptr          , check_equals_integer_ptr &
+       ,check_less_than_real_ptr               , check_greater_than_real_ptr &
+       ,check_less_than_double_ptr             , check_greater_than_double_ptr &
+       ,check_less_than_integer_ptr            , check_greater_than_integer_ptr &
+       ,check_less_than_or_equal_to_integer_ptr, check_greater_than_or_equal_to_integer_ptr
        
-     check_approximates_real_ptr => check_approximates_real
-     check_approximatees_double_ptr => check_approximatees_double
-     check_equals_integer_ptr => check_equals_integer
-     check_less_than_real_ptr => check_less_than_real
-     check_less_than_double_ptr => check_less_than_double
-     check_less_than_integer_ptr => check_less_than_integer
-     check_less_than_or_equal_to_integer_ptr => check_less_than_or_equal_to_integer
+     check_approximates_real_ptr                => check_approximates_real
+     check_approximates_double_ptr             => check_approximates_double
+     check_equals_integer_ptr                   => check_equals_integer
+     check_less_than_real_ptr                   => check_less_than_real
+     check_less_than_double_ptr                 => check_less_than_double
+     check_less_than_integer_ptr                => check_less_than_integer
+     check_less_than_or_equal_to_integer_ptr    => check_less_than_or_equal_to_integer
+     check_greater_than_real_ptr                => check_greater_than_real
+     check_greater_than_double_ptr              => check_greater_than_double
+     check_greater_than_integer_ptr             => check_greater_than_integer
      check_greater_than_or_equal_to_integer_ptr => check_greater_than_or_equal_to_integer
 
      descriptions = [ &
-       test_description_t("contruction from a real expression of the form `x .approximates. y .within. tolerance`", check_approximates_real_ptr) &
-      ,test_description_t("contruction from a double-precision expression of the form `x .approximates. y .within. tolerance`", check_approximatees_double_ptr) &
-      ,test_description_t("contruction from an integer expression of the form `i .equalsExpected. j`", check_equals_integer_ptr) &
-      ,test_description_t("contruction from a real expression of the form 'x .lessThan. y", check_less_than_real_ptr) &
-      ,test_description_t("contruction from a double precision expression of the form 'x .lessThan. y", check_less_than_double_ptr) &
-      ,test_description_t("contruction from a integer expression of the form 'i .lessThan. j", check_less_than_integer_ptr) &
-      ,test_description_t("contruction from a real expression of the form 'x .greaterThan. y", check_greater_than_real_ptr) &
-      ,test_description_t("contruction from a double precision expression of the form 'x .greaterThan. y", check_greater_than_double_ptr) &
-      ,test_description_t("contruction from a integer expression of the form 'i .greaterThan. j", check_greater_than_integer_ptr) &
-      ,test_description_t("contruction from a integer expression of the form 'i .lessThanOrEqualTo. j", check_less_than_or_equal_to_integer_ptr) &
-      ,test_description_t("contruction from a integer expression of the form 'i .greaterThanOrEqualTo. j", check_greater_than_or_equal_to_integer_ptr) &
+       test_description_t("contruction from a real expression of the form `x .approximates. y .within. tolerance`"            , check_approximates_real_ptr) &
+      ,test_description_t("contruction from a double-precision expression of the form `x .approximates. y .within. tolerance`", check_approximates_double_ptr) &
+      ,test_description_t("contruction from an integer expression of the form `i .equalsExpected. j`"                         , check_equals_integer_ptr) &
+      ,test_description_t("contruction from a real expression of the form 'x .lessThan. y"                                    , check_less_than_real_ptr) &
+      ,test_description_t("contruction from a double precision expression of the form 'x .lessThan. y"                        , check_less_than_double_ptr) &
+      ,test_description_t("contruction from a integer expression of the form 'i .lessThan. j"                                 , check_less_than_integer_ptr) &
+      ,test_description_t("contruction from a integer expression of the form 'i .lessThanOrEqualTo. j"                        ) & ! skip check_less_than_or_equal_to_integer_ptr
+      ,test_description_t("contruction from a real expression of the form 'x .greaterThan. y"                                 , check_greater_than_real_ptr) &
+      ,test_description_t("contruction from a double precision expression of the form 'x .greaterThan. y"                     , check_greater_than_double_ptr) &
+      ,test_description_t("contruction from a integer expression of the form 'i .greaterThan. j"                              , check_greater_than_integer_ptr) &
+      ,test_description_t("contruction from a integer expression of the form 'i .greaterThanOrEqualTo. j"                     ) & ! skip check_greater_than_or_equal_to_integer_ptr
      ]
 #endif
 
@@ -121,7 +127,7 @@ contains
     test_diagnosis = 1. .approximates. expected_value .within. tolerance
   end function
 
-  function check_approximatees_double() result(test_diagnosis)
+  function check_approximates_double() result(test_diagnosis)
     type(test_diagnosis_t) test_diagnosis
     double precision, parameter :: expected_value = 1D0, tolerance = 1D-16
     test_diagnosis = 1D0 .approximates. expected_value .within. tolerance

--- a/test/test_diagnosis_test_m.F90
+++ b/test/test_diagnosis_test_m.F90
@@ -59,7 +59,8 @@ contains
       ,test_description_t("contruction from a integer expression of the form 'i .greaterThan. j", check_greater_than_integer) &
       ,test_description_t("contruction from a integer expression of the form '[i,j] .lessThanOrEqualTo. k", check_less_than_or_equal_to_integer) &
       ,test_description_t("contruction from a integer expression of the form '[i,j] .greaterThanOrEqualTo. k", check_greater_than_or_equal_to_integer) &
-      ,test_description_t("contruction from a test_diagnostics_t expression of the form 't .and. u'", check_and_operator) &
+      ,test_description_t("contruction from a scalar test_diagnostics_t expression of the form 't .and. u'", check_and_with_scalar_operands) &
+      ,test_description_t("contruction from vector test_diagnostics_t expressions with operands like 'i .equalsExpected. [j,k]'", check_and_with_vector_operands) &
     ] )
 #else
      ! Work around missing Fortran 2008 feature: associating a procedure actual argument with a procedure pointer dummy argument:
@@ -71,7 +72,8 @@ contains
        ,check_less_than_double_ptr             , check_greater_than_double_ptr &
        ,check_less_than_integer_ptr            , check_greater_than_integer_ptr &
        ,check_less_than_or_equal_to_integer_ptr, check_greater_than_or_equal_to_integer_ptr &
-       ,check_and_operator_ptr
+       ,check_and_with_scalar_operands_ptr &
+       ,check_and_with_vector_operands_ptr
 
      check_approximates_real_ptr                => check_approximates_real
      check_approximates_double_ptr             => check_approximates_double
@@ -84,7 +86,8 @@ contains
      check_greater_than_double_ptr              => check_greater_than_double
      check_greater_than_integer_ptr             => check_greater_than_integer
      check_greater_than_or_equal_to_integer_ptr => check_greater_than_or_equal_to_integer
-     check_and_operator_ptr                     => check_and_operator
+     check_and_with_scalar_operands_ptr         => check_and_with_scalar_operands
+     check_and_with_vector_operands_ptr         => check_and_with_vector_operands
 
      descriptions = [ &
        test_description_t("contruction from a real expression of the form `x .approximates. y .within. tolerance`"            , check_approximates_real_ptr) &
@@ -98,7 +101,9 @@ contains
       ,test_description_t("contruction from a double precision expression of the form 'x .greaterThan. y"                     , check_greater_than_double_ptr) &
       ,test_description_t("contruction from a integer expression of the form 'i .greaterThan. j"                              , check_greater_than_integer_ptr) &
       ,test_description_t("contruction from a integer expression of the form 'i .greaterThanOrEqualTo. j") & ! skip check_greater_than_or_equal_to_integer_ptr
-      ,test_description_t("contruction from a test_diagnostics_t expression of the form 't .and. u'"     ) & ! skip check_and_operator_ptr
+      ,test_description_t("contruction from a scalar test_diagnostics_t expression with operands like 'i .equalsExpected. j'"  ) & ! skip check_and_with_scalar_operands_ptr
+      ,test_description_t("contruction from test_diagnostics_t vector expressions with operands like 'i .equalsExpected. [j,k]'") & ! skip check_and_with_vector_operands_ptr
+  check_and_with_vector_operands
      ]
 #endif
 
@@ -192,10 +197,15 @@ contains
     test_diagnosis = .all. ([1,2] .greaterThanOrEqualTo. expected_min)
   end function
 
-  function check_and_operator() result(test_diagnosis)
+  function check_and_with_scalar_operands() result(test_diagnosis)
     type(test_diagnosis_t) test_diagnosis
     integer, parameter :: expected_min = 1
     test_diagnosis = (2 .greaterThanOrEqualTo. expected_min) .and. (1 .equalsExpected. 1)
+  end function
+
+  function check_and_with_vector_operands() result(test_diagnoses)
+    type(test_diagnosis_t) test_diagnoses
+    test_diagnoses = .all. ((2 .equalsExpected. [2,2,2]) .and. ([0,1,2] .equalsExpected. [0,1,2]))
   end function
 
 end module test_diagnosis_test_m

--- a/test/test_diagnosis_test_m.F90
+++ b/test/test_diagnosis_test_m.F90
@@ -17,6 +17,7 @@ module test_diagnosis_test_m
     ,diagnosis_function_i &
 #endif
     ,operator(.all.) &
+    ,operator(.and.) &
     ,operator(.equalsExpected.) &
     ,operator(.approximates.) &
     ,operator(.within.) &
@@ -58,6 +59,7 @@ contains
       ,test_description_t("contruction from a integer expression of the form 'i .greaterThan. j", check_greater_than_integer) &
       ,test_description_t("contruction from a integer expression of the form '[i,j] .lessThanOrEqualTo. k", check_less_than_or_equal_to_integer) &
       ,test_description_t("contruction from a integer expression of the form '[i,j] .greaterThanOrEqualTo. k", check_greater_than_or_equal_to_integer) &
+      ,test_description_t("contruction from a test_diagnostics_t expression of the form 't .and. u'", check_and_operator) &
     ] )
 #else
      ! Work around missing Fortran 2008 feature: associating a procedure actual argument with a procedure pointer dummy argument:
@@ -68,8 +70,9 @@ contains
        ,check_less_than_real_ptr               , check_greater_than_real_ptr &
        ,check_less_than_double_ptr             , check_greater_than_double_ptr &
        ,check_less_than_integer_ptr            , check_greater_than_integer_ptr &
-       ,check_less_than_or_equal_to_integer_ptr, check_greater_than_or_equal_to_integer_ptr
-       
+       ,check_less_than_or_equal_to_integer_ptr, check_greater_than_or_equal_to_integer_ptr &
+       ,check_and_operator_ptr
+
      check_approximates_real_ptr                => check_approximates_real
      check_approximates_double_ptr             => check_approximates_double
      check_equals_integer_ptr                   => check_equals_integer
@@ -81,6 +84,7 @@ contains
      check_greater_than_double_ptr              => check_greater_than_double
      check_greater_than_integer_ptr             => check_greater_than_integer
      check_greater_than_or_equal_to_integer_ptr => check_greater_than_or_equal_to_integer
+     check_and_operator_ptr                     => check_and_operator
 
      descriptions = [ &
        test_description_t("contruction from a real expression of the form `x .approximates. y .within. tolerance`"            , check_approximates_real_ptr) &
@@ -89,11 +93,12 @@ contains
       ,test_description_t("contruction from a real expression of the form 'x .lessThan. y"                                    , check_less_than_real_ptr) &
       ,test_description_t("contruction from a double precision expression of the form 'x .lessThan. y"                        , check_less_than_double_ptr) &
       ,test_description_t("contruction from a integer expression of the form 'i .lessThan. j"                                 , check_less_than_integer_ptr) &
-      ,test_description_t("contruction from a integer expression of the form 'i .lessThanOrEqualTo. j"                        ) & ! skip check_less_than_or_equal_to_integer_ptr
+      ,test_description_t("contruction from a integer expression of the form 'i .lessThanOrEqualTo. j"   ) & ! skip check_less_than_or_equal_to_integer_ptr
       ,test_description_t("contruction from a real expression of the form 'x .greaterThan. y"                                 , check_greater_than_real_ptr) &
       ,test_description_t("contruction from a double precision expression of the form 'x .greaterThan. y"                     , check_greater_than_double_ptr) &
       ,test_description_t("contruction from a integer expression of the form 'i .greaterThan. j"                              , check_greater_than_integer_ptr) &
-      ,test_description_t("contruction from a integer expression of the form 'i .greaterThanOrEqualTo. j"                     ) & ! skip check_greater_than_or_equal_to_integer_ptr
+      ,test_description_t("contruction from a integer expression of the form 'i .greaterThanOrEqualTo. j") & ! skip check_greater_than_or_equal_to_integer_ptr
+      ,test_description_t("contruction from a test_diagnostics_t expression of the form 't .and. u'"     ) & ! skip check_and_operator_ptr
      ]
 #endif
 
@@ -185,6 +190,12 @@ contains
     type(test_diagnosis_t) test_diagnosis
     integer, parameter :: expected_min = 1
     test_diagnosis = .all. ([1,2] .greaterThanOrEqualTo. expected_min)
+  end function
+
+  function check_and_operator() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    integer, parameter :: expected_min = 1
+    test_diagnosis = (2 .greaterThanOrEqualTo. expected_min) .and. (1 .equalsExpected. 1)
   end function
 
 end module test_diagnosis_test_m


### PR DESCRIPTION
This pull request adds user-defined operators and corresponding unit tests.  The primary benefit of using these operators is that they eliminate some of the tedium of forming one's own `diagnostics_string` arguments when invoking `test_diagnosis_t` constructors.

For `real` or `double precision` values `x`, `y`, and `tolerance` and for integer values `i` and `j`,  expressions of the following forms now evaluate to `test_diagnosis_t` objects constructed with descriptive `diagnostic_string` arguments tailored to the operators involved in the expressions:
```fortran
x .approximates. y .within. tolerance
x .lessThan. y
x .greaterThan. y

i .equalsExpected. j
i .lessThan. j
i .greaterThan. j
i .lessThanOrEqualTo. j
i .greaterThanOrEqualTo. j
```
where all of the above operators are `elemental` and accept conformable arguments, i.e.,  same-shaped array operands or array/scalar operand combinations.

When the operands are arrays, the expressions evaluate to `test_diagnosis_t` arrays, which could be used as the `result` of a vector test function satisfying Julienne's `vector_diagnosis_function_i` abstract interface.  Alternatively, array results can be aggregated into one `test_diagnosis_t` object using the `.all.` operator that this pull request also provides.  For example,
```fortran
.all. ([i,j] .lessThan. k).   ! test passes if i < k .and. j < k
.all. (i .greaterThan. [j,k]) ! test passes if i > j .and. i > k 
.all. ([i,j] .equalsExpected. [m,n]) ! test passes if i == m .and. j == n
````
where expressions operated on by `.all.` will result in diagnostic strings displaying only for the elements corresponding to test failures.  See [`test/test_diagnosis_test_m.F90`] for examples of the use of the above operators.

Equivalently, if pairwise aggregation suffices, then the user-defined `.and.` operator in this PR can be used as follows:
```fortran
(2 .greaterThanOrEqualTo. expected_min) .and. (1 .equalsExpected. 1)
```
which is currently implemented using `.all.` with a size-2 array:
```fortran
.all. ([lhs,rhs])
```
where `lhs  = 2 .greaterThanOrEqualTo. expected_min` and `rhs = 1 .equalsExpected. 1`.

To Do
------
 
- [ ] In the expression `x .approximates. y .within. tolerance`, switch the internal logic from using `< tolerance` to using `<= tolerance` in order to handle the (not necessarily recommended) case of `tolerance==0.`. 

[`test/test_diagnosis_test_m.F90`]: https://github.com/BerkeleyLab/julienne/blob/test-diagnosis-expressions/test/test_diagnosis_test_m.F90