### PR TITLE
Feature: no longer skip testing the `string_t` bracket() function if GCC > 14.2

### DIFF
--- a/include/language-support.F90
+++ b/include/language-support.F90
@@ -4,6 +4,8 @@
 #ifndef _JULIENNE_LANGUAGE_SUPPORT_H
 #define _JULIENNE_LANGUAGE_SUPPORT_H
 
+#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+
 ! If not already determined, make a compiler-dependent determination of whether Julienne may pass
 ! procedure actual arguments to procedure pointer dummy arguments, a feature introduced in
 ! Fortran 2008 and described in Fortran 2023 clause 15.5.2.10 paragraph 5.

--- a/test/modules/string_test_m.F90
+++ b/test/modules/string_test_m.F90
@@ -164,16 +164,14 @@ contains
       ,test_description_t('extracting a file base name',                                                   extracts_file_base_name_ptr)&
       ,test_description_t('extracting a file name extension',                                         extracts_file_name_extension_ptr)&
       ,test_description_t('supporting unary operator(.cat.) for array arguments',                            concatenates_elements_ptr)&
-#ifndef __GFORTRAN__
-      ,test_description_t('constructing bracketed strings',                                                       brackets_strings_ptr)&
-#else
-      ! Because this test crashes due to a gfortran bug, we construct the test_description_t object without a test_diagnosis_t
-      ! function, which will cause the test to be skipped and reported as such in test_result_t's "run" function.
-      ,test_description_t('constructing bracketed strings'                                                                            )&
-#endif
       ,test_description_t("extracting a string_t array value from a colon-separated key/value pair",   extracts_string_array_value_ptr)&
       ,test_description_t('constructing (comma-)separated values from character or string_t arrays',   constructs_separated_values_ptr)&
       ,test_description_t('constructing from a double-precision complex value',           constructs_from_double_precision_complex_ptr)&
+#if GCC_VERSION > 140200
+      ,test_description_t('constructing bracketed strings',                                                       brackets_strings_ptr) &
+#else
+      ,test_description_t('constructing bracketed strings') &
+#endif
     ]
 #endif
     test_descriptions = pack(test_descriptions, &


### PR DESCRIPTION
This commit reintroduces the test for the `string_t` type-bound function `bracket()` if the GCC version is greater than 14.2.