### PR TITLE
build(assert): use 3.0.0-rc1

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,7 +1,7 @@
 name = "julienne"
 
 [dependencies]
-assert = {git = "https://github.com/rouson/assert", tag = "assert-3.0.0"}
+assert = {git = "https://github.com/rouson/assert", tag = "3.0.0-rc-1"}
 
 [install]
 library = true


### PR DESCRIPTION
This updates the Assert dependency version to 3.0.0 release candidate 1, which enables Assert to build correctly with LFortran.