### PR TITLE
Add specific procedure for call_julienne_assert_ generic interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ Getting Started
 ---------------
 ### Writing Assertions
 To write a Julienne assertion, insert a function-like preprocessor macro
-`call_julienne_assert` on a single line as in the following program:
+`call_julienne_assert` on a single line as in each of the two macro
+invocations below:
 ```fortran
 #include "julienne-assertion-macros.h"
 program main
@@ -164,14 +165,24 @@ program main
   implicit none
   real, parameter :: x=1., y=2., tolerance=3.
   call_julienne_assert(x .approximates. y .within. tolerance)
+  call_julienne_assert(abs(x-y) < tolerance)
 end program
 ```
-where inserting `-DASSERTIONS` in a compile command will expand the macro to
+where inserting `-DASSERTIONS` in a compile command will expand the macros to
 ```fortran
-  call call_julienne_assert_(x .approximates. y .within. tolerance)
+  call call_julienne_assert_(x .approximates. y .within. tolerance, __FILE__, __LINE__)
+  call call_julienne_assert_(abs(x-y) <  tolerance, __FILE__, __LINE__)
 ```
-and where dots (`.`) delimit Julienne operators and the parenthetical expression
-evaluates to a Julienne `test_diagnosis_t` object.
+and where dots (`.`) delimit Julienne operators.  The above expression containing
+Julienne operators evaluates to a Julienne `test_diagnosis_t` object, whereas
+expression on the subsequent line containing intrinsic operators evaluates to a
+`logical` value.  If an assertion containing a Julienne expression fails, the
+error stop code will contain diagnostic information constructed automatically by
+Julienne. If an assertion containing a `logical` experession evaluates to `false.`,
+the error stop code will contain a literal copy of the expression.  In either
+case, the error stop code will also contain the file and line number, which the
+function-like macro inserts automatically via the `__FILE__` and `__LINE__` macros,
+respectively.
 
 ### Writing Unit Tests
 Writing tests using Julienne involves constructing a test-description array,

--- a/src/julienne/julienne_test_diagnosis_m.F90
+++ b/src/julienne/julienne_test_diagnosis_m.F90
@@ -60,11 +60,22 @@ module julienne_test_diagnosis_m
   interface call_julienne_assert_
 
     pure module subroutine julienne_assert(test_diagnosis, file, line)
+      !! Public procedure.
       !! Use cases:
       !!   1. When invoked via the generic interface, the preprocessor passes the 'file' and 'line' dummy arguments automatically.
       !!   2. When invoked directly, there is 1 argument: an expression containing defined operations such as 1 .equalsExpected. 1
       implicit none
       type(test_diagnosis_t), intent(in) :: test_diagnosis
+      character(len=*), intent(in), optional :: file
+      integer, intent(in), optional :: line
+    end subroutine
+
+    pure module subroutine assert_assert(assertion, file, line)
+      !! Private wrapper for the assert subroutine in the Assert library (https://go.lbl.gov/assert).
+      !! Invoke this procedure via the call_julienne_assert_ generic interface with only the required logical argument.
+      !! The preprocessor will insert the optional 'file' and 'line' arguments.
+      implicit none
+      logical, intent(in) :: assertion
       character(len=*), intent(in), optional :: file
       integer, intent(in), optional :: line
     end subroutine

--- a/src/julienne/julienne_test_diagnosis_s.F90
+++ b/src/julienne/julienne_test_diagnosis_s.F90
@@ -549,4 +549,12 @@ contains
     call assert_always(test_diagnosis%test_passed_, diagnostics_string)
   end procedure
 
+  module procedure assert_assert
+    character(len=:), allocatable :: diagnostics_string
+    diagnostics_string = ""
+    if (present(file)) diagnostics_string = diagnostics_string // " in file " // file
+    if (present(line)) diagnostics_string = diagnostics_string // " at line " // string_t(line)
+    call assert_always(assertion, diagnostics_string)
+  end procedure
+
 end submodule julienne_test_diagnosis_s

--- a/test/modules/assert_test_m.F90
+++ b/test/modules/assert_test_m.F90
@@ -40,7 +40,8 @@ contains
     type(test_result_t), allocatable :: test_results(:)
 
     associate(descriptions => [ &
-       test_description_t("invocation with an expression containing Julienne operators", check_macro_with_expression) &
+       test_description_t("invocation with an expression containing Julienne operators", check_macro_with_julienne_idiom) &
+      ,test_description_t("invocation with a logical expression", check_macro_with_logical_assertion) &
     ])
       associate(substring_in_subject => index(subject(), test_description_substring) /= 0)
         associate(substring_in_test_diagnosis => descriptions%contains_text(test_description_substring))
@@ -61,10 +62,12 @@ contains
     type(test_result_t), allocatable :: test_results(:)
     type(test_description_t), allocatable :: descriptions(:)
     procedure(diagnosis_function_i), pointer :: &
-       check_macro_with_expression_ptr => check_macro_with_expression
+       check_macro_with_julienne_idiom_ptr => check_macro_with_julienne_idiom &
+      ,check_macro_with_logical_assertion_ptr => check_macro_with_logical_assertion
 
     descriptions = [ &
        test_description_t("invocation via macro with an expression containing Julienne operators", check_macro_with_expression_ptr)&
+      ,test_description_t("invocation with a logical expression", check_macro_with_logical_assertion_ptr) &
     ]
 
     block
@@ -81,10 +84,15 @@ contains
 
 #endif
 
-  function check_macro_with_expression() result(test_diagnosis)
+  function check_macro_with_julienne_idiom() result(test_diagnosis)
     type(test_diagnosis_t) test_diagnosis
     call_julienne_assert(1. .approximates. 2. .within. 3.)
     test_diagnosis = test_diagnosis_t(.true., "")
+  end function
+
+  function check_macro_with_logical_assertion() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    call_julienne_assert(1==1)
   end function
 
 end module assert_test_m


### PR DESCRIPTION
The new `assert_assert` procedure behaves similarly to `julienne_assert`, but the two non-optional dummy arguments in `assert_assert` have the same type and purpose as the corresponding arguments in the [Assert](https://go.lbl.gov/assert) library's `assert_always` subroutine.   `Assert_assert` is therefore a slightly thinner wrapper around `assert_always` and is useful when the assertion is a simple `logical` function that can be usefully described in an error message by simply transcribing the function, e.g., `allocated(array)`.