### PR TITLE
Feature: Add compiler abstraction

### DIFF
--- a/src/julienne/julienne_compiler_m.f90
+++ b/src/julienne/julienne_compiler_m.f90
@@ -1,0 +1,27 @@
+! Copyright (c) 2024-2025, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
+
+module julienne_compiler_m
+  !! Compiler identity abstraction
+  use iso_fortran_env ,only : compiler_version
+  implicit none
+
+  private
+  public :: compiler_t
+
+  type compiler_t
+    private
+    character(len=:), allocatable :: name_
+    integer :: major_version_, minor_version_, patch_version_
+  end type
+
+  interface compiler_t
+
+    module function inspect_compiler() result(compiler)
+      implicit none
+      type(compiler_t) compiler
+    end function
+
+  end interface 
+
+end module julienne_compiler_m

--- a/src/julienne/julienne_compiler_s.F90
+++ b/src/julienne/julienne_compiler_s.F90
@@ -1,0 +1,44 @@
+! Copyright (c) 2024-2025, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
+
+#include "assert_macros.h"
+#include "julienne-assert-macros.h"
+
+submodule(julienne_compiler_m) compiler_identity_s
+  use iso_fortran_env ,only : compiler_version
+  use julienne_m, only : call_julienne_assert_, operator(.isAtLeast.)
+  use assert_m
+  implicit none
+
+contains
+
+  module procedure inspect_compiler
+    character(len=:), allocatable :: compiler_identity
+
+    compiler_identity = compiler_version()
+
+    if (index(compiler_identity, "GCC")==1) then
+      compiler%name_ = "gfortran"
+      associate(               final_dot => index(compiler_identity                     ,"." ,back=.true.))
+        associate(       penultimate_dot => index(compiler_identity(:final_dot-1)       ,"." ,back=.true.))
+          associate(space_before_version => index(compiler_identity(:penultimate_dot-1) ," " ,back=.true.))
+            associate( &
+               major_string => compiler_identity(space_before_version+1 : penultimate_dot-1) &
+              ,minor_string => compiler_identity(     penultimate_dot+1 :       final_dot-1) &
+              ,patch_string => compiler_identity(           final_dot+1 :                  ) &
+            )
+              read(major_string, '(i2)') compiler%major_version_
+              read(minor_string, '(i1)') compiler%minor_version_
+              read(patch_string, '(i1)') compiler%patch_version_
+            end associate
+          end associate
+        end associate
+      end associate
+    else
+       error stop "_____ unrecognized compiler _____"
+    end if
+
+    call_assert(allocated(compiler%name_)) 
+    call_julienne_assert([compiler%major_version_, compiler%major_version_, compiler%major_version_] .isAtLeast. 1)
+  end procedure
+end submodule compiler_identity_s

--- a/src/julienne_m.f90
+++ b/src/julienne_m.f90
@@ -6,6 +6,7 @@ module julienne_m
   use julienne_assert_m, only : call_julienne_assert_, julienne_assert
   use julienne_bin_m, only : bin_t
   use julienne_command_line_m, only : command_line_t
+  use julienne_compiler_m, only : compiler_t
   use julienne_file_m, only : file_t
   use julienne_formats_m, only : separated_values, csv
   use julienne_github_ci_m, only : github_ci


### PR DESCRIPTION
This commit adds compiler_t type that encapsulates the compiler name and major/minor/patch versions as extracted by parsing the result of the compiler_version() intrinsic function.