### PR TITLE
Add test_diagnosis_t operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ operators in addition to overloading Fortran's intrinsic operators.  The
 following table provides examples of the expressions Julienne supports:
 
 Example expressions                               | Operand types
---------------------------------------------------|--------------------------------------
+--------------------------------------------------|-----------------------------------------------------------
 `x .approximates. y .within. tolerance`           | `real`, `double precision`
 `x .approximates. y .withinFraction. tolerance`   | `real`, `double precision`
 `x .approximates. y .withinPercentage. tolerance` | `real`, `double precision`
@@ -24,7 +24,7 @@ Example expressions                               | Operand types
 `(i .lessThan. j) .also. (k .equalsExpected. m))` | `integer`, `real`, `double precision`
 `x .lessThan. y`                                  | `integer`, `real`, `double precision`
 `x .greaterThan. y`                               | `integer`, `real`, `double precision`
-`i .equalsExpected. j`                            | `integer`, `character`
+`i .equalsExpected. j`                            | `integer`, `character`, `type(c_ptr)`
 `i .isAtLeast. j`                                 | `integer`, `real`, `double precision`
 `i .isAtMost. j`                                  | `integer`, `real`, `double precision`
 `s .isBefore. t`                                  | `character`
@@ -34,6 +34,7 @@ Example expressions                               | Operand types
 where 
 * `.isAtLeast.` and `.isAtMost.` can alternatively be spelled `.greaterThanOrEqualTo.` and `.lessThanOrEqualTo.`, respectively;
 * `.equalsExpected.` uses `==`, which implies that trailing blank spaces are ignored in character operands;  
+* `.equalsExpected.` with integer operands supports default integers and `integer(c_size_t)`;
 * `.isBefore.` and `.isAfter.` verify alphabetical and reverse-alphabetical  order, respectively; 
 * `.all.` aggregates arrays of expression results, reports a consensus result, passes, and shows diagnostics only for failing tests, if any; and
 * `.equalsExpected.` generates asymmetric diagnostic output for failures, denoting the left- and right-hand sides as the actual value and expected values, respectively.

--- a/src/julienne/julienne_string_m.F90
+++ b/src/julienne/julienne_string_m.F90
@@ -2,7 +2,7 @@
 ! Terms of use are as specified in LICENSE.txt
 
 module julienne_string_m
-  use iso_c_binding, only : c_bool
+  use iso_c_binding, only : c_bool, c_size_t
   implicit none
   
   private
@@ -68,6 +68,12 @@ module julienne_string_m
     elemental module function from_default_integer(i) result(string)
       implicit none
       integer, intent(in) :: i
+      type(string_t) string
+    end function
+
+    elemental module function from_integer_c_size_t(i) result(string)
+      implicit none
+      integer(c_size_t), intent(in) :: i
       type(string_t) string
     end function
 

--- a/src/julienne/julienne_string_s.F90
+++ b/src/julienne/julienne_string_s.F90
@@ -10,8 +10,8 @@ submodule(julienne_string_m) julienne_string_s
   use julienne_test_diagnosis_m, only : operator(.equalsExpected.)
   implicit none
 
-  integer, parameter :: integer_width_supremum = 11, default_real_width_supremum = 20, double_precision_width_supremum = 25
-  integer, parameter :: logical_width=2, comma_width = 1, parenthesis_width = 1, space=1
+  integer, parameter :: default_integer_width_supremum = 11, default_real_width_supremum = 20, double_precision_width_supremum = 25
+  integer, parameter :: integer_c_size_t_width_supremum = 19, logical_width=2, comma_width = 1, parenthesis_width = 1, space=1
   
 contains
 
@@ -28,7 +28,13 @@ contains
   end procedure
 
   module procedure from_default_integer
-    allocate(character(len=integer_width_supremum) :: string%string_)
+    allocate(character(len=default_integer_width_supremum) :: string%string_)
+    write(string%string_, '(g0)') i
+    string%string_ = trim(adjustl(string%string_))
+  end procedure
+
+  module procedure from_integer_c_size_t
+    allocate(character(len=integer_c_size_t_width_supremum) :: string%string_)
     write(string%string_, '(g0)') i
     string%string_ = trim(adjustl(string%string_))
   end procedure

--- a/src/julienne/julienne_test_diagnosis_m.F90
+++ b/src/julienne/julienne_test_diagnosis_m.F90
@@ -6,6 +6,7 @@
 module julienne_test_diagnosis_m
   !! Define abstractions, defined operations, and procedures for writing correctness checks
   use julienne_string_m, only : string_t
+  use iso_c_binding, only : c_size_t
   implicit none
 
   private
@@ -224,6 +225,12 @@ module julienne_test_diagnosis_m
     elemental module function equals_expected_integer(actual, expected) result(test_diagnosis)
       implicit none
       integer, intent(in) :: actual, expected
+      type(test_diagnosis_t) test_diagnosis
+    end function
+
+    elemental module function equals_expected_integer_c_size_t(actual, expected) result(test_diagnosis)
+      implicit none
+      integer(c_size_t), intent(in) :: actual, expected
       type(test_diagnosis_t) test_diagnosis
     end function
 

--- a/src/julienne/julienne_test_diagnosis_m.F90
+++ b/src/julienne/julienne_test_diagnosis_m.F90
@@ -6,7 +6,7 @@
 module julienne_test_diagnosis_m
   !! Define abstractions, defined operations, and procedures for writing correctness checks
   use julienne_string_m, only : string_t
-  use iso_c_binding, only : c_size_t
+  use iso_c_binding, only : c_size_t, c_ptr
   implicit none
 
   private
@@ -240,6 +240,12 @@ module julienne_test_diagnosis_m
   end interface
 
   interface operator(.equalsExpected.)
+
+    elemental module function equals_expected_c_ptr(actual, expected) result(test_diagnosis)
+      implicit none
+      type(c_ptr), intent(in) :: actual, expected
+      type(test_diagnosis_t) test_diagnosis
+    end function
 
     elemental module function equals_expected_integer(actual, expected) result(test_diagnosis)
       implicit none

--- a/src/julienne/julienne_test_diagnosis_m.F90
+++ b/src/julienne/julienne_test_diagnosis_m.F90
@@ -12,23 +12,24 @@ module julienne_test_diagnosis_m
   private
   public :: test_diagnosis_t
   public :: diagnosis_function_i
+  public :: operator(//)
   public :: operator(.all.)
-  public :: operator(.and.)
   public :: operator(.also.)
+  public :: operator(.and.)
   public :: operator(.approximates.)
+  public :: operator(.isAfter.)
   public :: operator(.isAtLeast.)
   public :: operator(.isAtMost.)
   public :: operator(.isBefore.)
-  public :: operator(.isAfter.)
+  public :: operator(.equalsExpected.)
+  public :: operator(.expect.)
+  public :: operator(.greaterThan.)
+  public :: operator(.greaterThanOrEqualTo.)
+  public :: operator(.lessThan.)
+  public :: operator(.lessThanOrEqualTo.)
   public :: operator(.within.)
   public :: operator(.withinFraction.)
   public :: operator(.withinPercentage.)
-  public :: operator(.equalsExpected.)
-  public :: operator(.expect.)
-  public :: operator(.lessThan.)
-  public :: operator(.lessThanOrEqualTo.)
-  public :: operator(.greaterThan.)
-  public :: operator(.greaterThanOrEqualTo.)
 
   type test_diagnosis_t
     !! Encapsulate test outcome and diagnostic information
@@ -36,8 +37,8 @@ module julienne_test_diagnosis_m
     logical :: test_passed_ = .false.
     character(len=:), allocatable :: diagnostics_string_
   contains
-    procedure test_passed
-    procedure diagnostics_string
+    procedure, non_overridable :: test_passed
+    procedure, non_overridable ::  diagnostics_string
   end type
 
   abstract interface
@@ -64,6 +65,24 @@ module julienne_test_diagnosis_m
     double precision actual, expected 
   end type
 #endif
+
+  interface operator(//)
+
+    elemental module function append_string_if_test_failed(lhs, rhs) result(lhs_cat_rhs)
+      implicit none
+      class(test_diagnosis_t), intent(in) :: lhs
+      type(string_t), intent(in) :: rhs
+      type(test_diagnosis_t) lhs_cat_rhs
+    end function
+
+    elemental module function append_character_if_test_failed(lhs, rhs) result(lhs_cat_rhs)
+      implicit none
+      class(test_diagnosis_t), intent(in) :: lhs
+      character(len=*), intent(in) :: rhs
+      type(test_diagnosis_t) lhs_cat_rhs
+    end function
+
+  end interface
 
   interface operator(.all.)
      

--- a/src/julienne/julienne_test_diagnosis_s.F90
+++ b/src/julienne/julienne_test_diagnosis_s.F90
@@ -10,6 +10,22 @@ submodule(julienne_test_diagnosis_m) julienne_test_diagnosis_s
   implicit none
 contains
 
+  module procedure append_string_if_test_failed
+    if (lhs%test_passed_) then
+      lhs_cat_rhs = lhs
+    else
+      lhs_cat_rhs = test_diagnosis_t(lhs%test_passed_, lhs%diagnostics_string_ // rhs)
+    end if
+  end procedure 
+
+  module procedure append_character_if_test_failed
+    if (lhs%test_passed_) then
+      lhs_cat_rhs = lhs
+    else
+      lhs_cat_rhs = test_diagnosis_t(lhs%test_passed_, lhs%diagnostics_string_ // rhs)
+    end if
+  end procedure 
+
   module procedure also
      diagnosis = .all. ([lhs,rhs])
   end procedure 

--- a/src/julienne/julienne_test_diagnosis_s.F90
+++ b/src/julienne/julienne_test_diagnosis_s.F90
@@ -248,6 +248,18 @@ contains
 
   end procedure
 
+  module procedure equals_expected_integer_c_size_t
+
+    if (actual == expected) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed = .false. &
+        ,diagnostics_string = "expected " // string_t(expected) // "; actual value is " // string_t(actual) &
+      )
+    end if
+
+  end procedure
+
   module procedure equals_expected_character
 
     if (actual == expected) then

--- a/src/julienne_m.f90
+++ b/src/julienne_m.f90
@@ -16,16 +16,17 @@ module julienne_m
     ,operator(.sv.)
   use julienne_test_description_m, only : test_description_t, filter
   use julienne_test_diagnosis_m, only   : test_diagnosis_t, diagnosis_function_i  &
+    ,operator(//) &
     ,operator(.all.) &
-    ,operator(.and.) &
     ,operator(.also.) &
+    ,operator(.and.) &
     ,operator(.approximates.) &
     ,operator(.equalsExpected.) &
     ,operator(.expect.) &
+    ,operator(.isAfter.) &
     ,operator(.isAtLeast.) &
     ,operator(.isAtMost.) &
     ,operator(.isBefore.) &
-    ,operator(.isAfter.) &
     ,operator(.lessThan.) &
     ,operator(.lessThanOrEqualTo.) &    ! same as operator(.isAtMost.)
     ,operator(.greaterThan.) &

--- a/test/modules/string_test_m.F90
+++ b/test/modules/string_test_m.F90
@@ -5,7 +5,7 @@
 
 module string_test_m
   use assert_m, only : assert
-  use iso_c_binding, only : c_bool
+  use iso_c_binding, only : c_bool, c_size_t
 
   use julienne_m, only : &
      test_t &
@@ -64,7 +64,7 @@ contains
       ,test_description_t('assigning a string_t object to a character variable',                     assigns_string_t_to_character)&
       ,test_description_t('assigning a character variable to a string_t object',                     assigns_character_to_string_t)&
       ,test_description_t('supporting operator(//) for string_t and character operands',           supports_concatenation_operator)&
-      ,test_description_t('constructing from a default integer',                                   constructs_from_default_integer)&
+      ,test_description_t('constructing from a default integer and an integer(c_size_t)',                 constructs_from_integers)&
       ,test_description_t('constructing from a default real value',                                   constructs_from_default_real)&
       ,test_description_t('constructing from a double-precision value',                           constructs_from_double_precision)&
       ,test_description_t('constructing from a default-precision complex value',                   constructs_from_default_complex)&
@@ -98,6 +98,7 @@ contains
       ,assigns_character_to_string_t_ptr            => assigns_character_to_string_t &
       ,supports_concatenation_operator_ptr          => supports_concatenation_operator &
       ,constructs_from_default_integer_ptr          => constructs_from_default_integer &
+      ,constructs_from_integers_ptr                 => constructs_from_integers &
       ,constructs_from_default_real_ptr             => constructs_from_default_real &
       ,constructs_from_double_precision_ptr         => constructs_from_double_precision &
       ,constructs_from_default_complex_ptr          => constructs_from_default_complex &
@@ -128,7 +129,7 @@ contains
       ,test_description_t('assigning a string_t object to a character variable',                     assigns_string_t_to_character_ptr)&
       ,test_description_t('assigning a character variable to a string_t object',                     assigns_character_to_string_t_ptr)&
       ,test_description_t('supporting operator(//) for string_t and character operands',           supports_concatenation_operator_ptr)&
-      ,test_description_t('constructing from a default integer',                                   constructs_from_default_integer_ptr)&
+      ,test_description_t('constructing from a default integer and an integer(c_size_t)',                 constructs_from_integers_ptr)&
       ,test_description_t('constructing from a default real value',                                   constructs_from_default_real_ptr)&
       ,test_description_t('constructing from a double-precision value',                           constructs_from_double_precision_ptr)&
       ,test_description_t('constructing from a default-precision complex value',                   constructs_from_default_complex_ptr)&
@@ -381,14 +382,19 @@ contains
     end associate
   end function
 
-  function constructs_from_default_integer() result(test_diagnosis)
+  function constructs_from_integers() result(test_diagnosis)
     type(test_diagnosis_t) test_diagnosis
-    integer, parameter :: expected_value = 1234567890
+    integer          , parameter :: expected_default_integer = 1234567890
+    integer(c_size_t), parameter :: expected_integer_c_size_t = 1234567890123456789_c_size_t
 
-    associate(string => string_t(expected_value))
+    associate(string_default_integer => string_t(expected_default_integer), string_c_size_t => string_t(expected_integer_c_size_t))
       test_diagnosis = test_diagnosis_t( &
-         test_passed = adjustl(trim(string%string())) == "1234567890" &
-        ,diagnostics_string = "expected '"// string_t(expected_value) // "', actual " // string%string() &
+         test_passed = adjustl(trim(string_default_integer%string())) == "1234567890" &
+        ,diagnostics_string = "expected '"// string_t(expected_default_integer) // "', actual " // string_default_integer%string() &
+      )
+      test_diagnosis = test_diagnosis .also. test_diagnosis_t( &
+         test_passed = adjustl(trim(string_c_size_t%string())) == "1234567890123456789" &
+        ,diagnostics_string = "expected '"// string_t(expected_integer_c_size_t) // "', actual " // string_c_size_t%string() &
       )
     end associate
   end function

--- a/test/modules/string_test_m.F90
+++ b/test/modules/string_test_m.F90
@@ -99,7 +99,6 @@ contains
       ,assigns_string_t_to_character_ptr            => assigns_string_t_to_character &
       ,assigns_character_to_string_t_ptr            => assigns_character_to_string_t &
       ,supports_concatenation_operator_ptr          => supports_concatenation_operator &
-      ,constructs_from_default_integer_ptr          => constructs_from_default_integer &
       ,constructs_from_integers_ptr                 => constructs_from_integers &
       ,constructs_from_default_real_ptr             => constructs_from_default_real &
       ,constructs_from_double_precision_ptr         => constructs_from_double_precision &

--- a/test/modules/test_diagnosis_test_m.F90
+++ b/test/modules/test_diagnosis_test_m.F90
@@ -31,6 +31,7 @@ module test_diagnosis_test_m
 #if ! HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
   use julienne_m, only : diagnosis_function_i
 #endif
+  use iso_c_binding, only : c_ptr, c_loc
   implicit none
 
   private
@@ -70,6 +71,7 @@ contains
       ,test_description_t("construction from string_t/character expressions 'a .isAfter. b'"                                   , check_reverse_alphabetical) &
       ,test_description_t("construction from string_t/character expressions 'a .equalsExpected. b'"                            , check_equals_character_vs_string) &
       ,test_description_t("construction from the character expression 'a .equalsExpected. b'"                                  , check_equals_character) &
+      ,test_description_t("construction from the type(c_ptr) expression 'p .equalsExpected. q'"                                , check_equals_c_ptr) &
       ,test_description_t("construction from the string_t expression 'a .equalsExpected. b'"                                   , check_equals_string) &
       ,test_description_t("construction from the integer expression 'i .equalsExpected. j'"                                    , check_equals_integer) &
       ,test_description_t("construction from the integer expression 'i .lessThan. j"                                           , check_less_than_integer) &
@@ -95,6 +97,7 @@ contains
        ,check_less_than_double_ptr                 => check_less_than_double &
        ,check_greater_than_double_ptr              => check_greater_than_double &
        ,check_equals_character_ptr                 => check_equals_character &
+       ,check_equals_c_ptr_ptr                     => check_equals_c_ptr &
        ,check_equals_string_ptr                    => check_equals_string &
        ,check_equals_character_vs_string_ptr       => check_equals_character_vs_string &
        ,check_reverse_alphabetical_ptr             => check_reverse_alphabetical &
@@ -124,6 +127,7 @@ contains
       ,test_description_t("construction from string_t/character expressions 'a .equalsExpected. b'"                            , check_equals_character_vs_string_ptr) &
       ,test_description_t("construction from string_t/character expressions 'a .isAfter. b'"                                   , check_reverse_alphabetical_ptr) &
       ,test_description_t("construction from the character expression 'a .equalsExpected. b'"                                  , check_equals_character_ptr) &
+      ,test_description_t("construction from the type(c_ptr) expression 'p .equalsExpected. q'"                                , check_equals_c_ptr_ptr) &
       ,test_description_t("construction from the string_t expression 'a .equalsExpected. b'"                                   , check_equals_string_ptr) &
       ,test_description_t("construction from the integer expression 'i .equalsExpected. j"                                     , check_equals_integer_ptr) &
       ,test_description_t("construction from the integer expression 'i .lessThan. j"                                           , check_less_than_integer_ptr) &
@@ -195,6 +199,15 @@ contains
     type(test_diagnosis_t) test_diagnosis
     character(len=*), parameter :: expected_value = "foo"
     test_diagnosis = "foo" .equalsExpected. expected_value
+  end function
+
+  function check_equals_c_ptr() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    logical, target :: t
+    type(c_ptr) t_ptr
+    t = .true.
+    t_ptr = c_loc(t)
+    test_diagnosis = t_ptr .equalsExpected. c_loc(t)
   end function
 
   function check_equals_string() result(test_diagnosis)


### PR DESCRIPTION
* `integer(c_size_t)` version of `operator(.equalsExpected.)`
* New `operator(//)` to append `string_t` value or `character` value to `diagnostics_string_` component
* Support `type(c_ptr)` operands for `.equalsExpected.` and report the operand addresses when equality is not satisfied.