### PR TITLE
Feature: centralize output to one image

### DIFF
--- a/src/julienne/julienne_one_image_prints_m.f90
+++ b/src/julienne/julienne_one_image_prints_m.f90
@@ -1,0 +1,25 @@
+! Copyright (c) 2024-2025, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
+
+module julienne_one_image_prints_m
+  use julienne_string_m, only : string_t
+  implicit none
+
+  private
+  public :: one_image_prints
+
+  interface one_image_prints
+
+    module subroutine print_string(string)
+      implicit none
+      type(string_t), intent(in) :: string(..)
+    end subroutine
+
+    module subroutine print_character(character_string)
+      implicit none
+      character(len=*), intent(in) :: character_string(..)
+    end subroutine
+
+  end interface
+
+end module julienne_one_image_prints_m

--- a/src/julienne/julienne_one_image_prints_s.f90
+++ b/src/julienne/julienne_one_image_prints_s.f90
@@ -1,0 +1,61 @@
+! Copyright (c) 2024-2025, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
+
+submodule(julienne_one_image_prints_m) julienne_one_image_prints_s
+  implicit none
+
+  integer, parameter :: printing_image = 1, me = 1
+
+contains
+
+  module procedure print_string
+#if HAVE_MULTI_IMAGE_SUPPORT
+    my_image: &
+    associate(me => this_image())
+#endif
+    if (printing_image == me) then
+      select rank(string)
+      rank(0)
+        print '(a)', string%string()
+      rank(1)
+        block
+          integer line
+          do line = 1, size(string)
+            print '(a)', string(line)%string()
+          end do
+        end block
+      rank default
+        error stop "print_string: unsupported rank"
+      end select
+    end if
+#if HAVE_MULTI_IMAGE_SUPPORT
+    end associate my_image
+#endif
+  end procedure
+
+  module procedure print_character
+#if HAVE_MULTI_IMAGE_SUPPORT
+    my_image: &
+    associate(me => this_image())
+#endif
+    if (printing_image == me) then
+      select rank(character_string)
+      rank(0)
+        print '(a)', character_string
+      rank(1)
+        block
+          integer line
+          do line = 1, size(character_string)
+            print '(a)', character_string(line)
+          end do
+        end block
+      rank default
+        error stop "print_character: unsupported rank"
+      end select
+    end if
+#if HAVE_MULTI_IMAGE_SUPPORT
+    end associate my_image
+#endif
+  end procedure
+
+end submodule julienne_one_image_prints_s

--- a/src/julienne/julienne_test_harness_s.F90
+++ b/src/julienne/julienne_test_harness_s.F90
@@ -5,6 +5,8 @@
 
 submodule(julienne_test_harness_m) julienne_test_harness_s
   use julienne_command_line_m, only : command_line_t
+  use julienne_one_image_prints_m, only : one_image_prints
+  use julienne_string_m, only : string_t
   implicit none
 
 contains
@@ -34,7 +36,7 @@ contains
       associate(me => this_image())
 #endif
         if (me==1) then
-          print '(a,*(a,:,g0))', new_line(''), "_____ ", passes, " of ", tests, " tests passed. ", skips, " tests were skipped _____"
+          call one_image_prints(new_line('') //  "_____ " // string_t(passes) // " of " // string_t(tests) // " tests passed. " // string_t(skips) // " tests were skipped _____")
           if (passes + skips /= tests) error stop "Some tests failed."
         end if
 
@@ -66,13 +68,12 @@ contains
             'the tests with test subjects or test descriptions containing the user-specified substring.' // new_line('')
 
           if (command_line%argument_present([character(len=len("--help"))::"--help","-h"])) then
-            if (me==1) print '(*(a))', usage
+            call one_image_prints(usage)
             stop
           end if
         end block
 
-        if (me==1) &
-          print "(a)", new_line("") // "Append '-- --help' or '-- -h' to your `fpm test` command to display usage information."
+        call one_image_prints(new_line("") // "Append '-- --help' or '-- -h' to your `fpm test` command to display usage information.")
 
       end associate
 

--- a/src/julienne/julienne_test_s.F90
+++ b/src/julienne/julienne_test_s.F90
@@ -5,6 +5,8 @@
 
 submodule(julienne_test_m) julienne_test_s
   use julienne_test_description_m, only : test_description_t
+  use julienne_one_image_prints_m, only : one_image_prints
+  use julienne_string_m, only : string_t
   implicit none
 
 contains
@@ -47,18 +49,17 @@ contains
               character(len=:), allocatable :: search_string
               search_string = command_line%flag_value("--contains")
               if (len(search_string)==0) then
-                print '(*(a))',           new_line('') // &
+                call one_image_prints( new_line('')    // &
                   "Running all tests." // new_line('') // &
-                  "(Add '-- --contains <string>' to run only tests with subjects or descriptions containing the specified string.)"
+                  "(Add '-- --contains <string>' to run only tests with subjects or descriptions containing the specified string.)")
               else
-                print '(*(a))',           new_line('') // &
-                  "Running only tests with subjects or descriptions containing '", search_string, "'."
+                call one_image_prints(new_line('') // "Running only tests with subjects or descriptions containing '" // search_string // "'.")
               end if
             end block
           end if first_report
         end block
 
-        print '(*(a))', new_line(''), test%subject()
+        call one_image_prints(new_line('') // test%subject())
 
       end if image_1_prints_usage_info
 
@@ -70,7 +71,7 @@ contains
             block
               integer i
               do i=1,num_tests
-                if (me==1) print '(3x,a)', test_results(i)%characterize()
+                call one_image_prints(test_results(i)%characterize())
               end do
             end block
           end if
@@ -84,7 +85,7 @@ contains
             call co_all(skipped_tests)
 
             associate(num_passes => count(passing_tests), num_skipped => count(skipped_tests))
-              if (me==1) print '(a,3(i0,a))'," ",num_passes," of ", num_tests," tests passed. ", num_skipped, " tests were skipped."
+              call one_image_prints(" " // string_t(num_passes) // " of " // string_t(num_tests) // " tests passed. " // string_t(num_skipped) // " tests were skipped.")
               passes = passes + num_passes
               skips  = skips  + num_skipped
             end associate
@@ -105,13 +106,13 @@ contains
           tests = tests + num_tests
           if (me==1) then
             do i=1,num_tests
-              if (me==1) print '(3x,a)', test_results(i)%characterize()
+              call one_image_prints(test_results(i)%characterize())
             end do
           end if
           passing_tests = test_results%passed()
           call co_all(passing_tests)
           associate(num_passes => count(passing_tests))
-            if (me==1) print '(a,2(i0,a))'," ",num_passes," of ", num_tests," tests passed."
+            call one_image_prints(" " // string_t(num_passes) // " of " // string_t(num_tests) // " tests passed.")
             passes = passes + num_passes
           end associate
         end associate

--- a/src/julienne_m.f90
+++ b/src/julienne_m.f90
@@ -9,6 +9,7 @@ module julienne_m
   use julienne_file_m, only : file_t
   use julienne_formats_m, only : separated_values, csv
   use julienne_github_ci_m, only : github_ci
+  use julienne_one_image_prints_m, only : one_image_prints
   use julienne_string_m, only : string_t, array_of_strings &
     ,operator(.cat.) &
     ,operator(.csv.) &

--- a/test/idiomatic_assertion_failure_test.F90
+++ b/test/idiomatic_assertion_failure_test.F90
@@ -6,7 +6,7 @@
 
 program idiomatic_assertion_failure_test
   !! Conditionally test an assertion that is hardwired to fail.
-  use julienne_m, only : call_julienne_assert_, command_line_t, operator(.equalsExpected.)
+  use julienne_m, only : call_julienne_assert_, command_line_t, operator(.equalsExpected.), one_image_prints
   implicit none
 
 #if HAVE_MULTI_IMAGE_SUPPORT
@@ -16,16 +16,15 @@ program idiomatic_assertion_failure_test
 #endif
     if (.not. command_line%argument_present([character(len=len("--help"))::"--help","-h"])) then
 #ifdef RUN_FALSE_ASSERTIONS
-      if (me==1) print '(a)', new_line('') // 'Test the intentional failure of an idiomatic assertion: ' // new_line('')
+      call one_image_prints(new_line('') // 'Test the intentional failure of an idiomatic assertion: ' // new_line(''))
       call_julienne_assert(1 .equalsExpected. 2)
 #else
-      if (me==1) then
-        print '(a)', &
+      call one_image_prints( &
            new_line('') // &
            'Skipping the test in ' // __FILE__ // '.' // new_line('') // &
            'Add the following to your fpm command to test assertion failures: --flag "-DASSERTIONS -DRUN_FALSE_ASSERTIONS"' // &
-           new_line('')
-      end if
+           new_line('') &
+      )
 #endif
     end if
   end associate

--- a/test/legacy-driver.F90
+++ b/test/legacy-driver.F90
@@ -63,7 +63,7 @@ program legacy_driver
         new_line("") // &
         "To test Julienne's command_line_t type, append the following to your fpm command:" // &
         new_line("") // &
-        "-- --test command_line_t --type"
+        "-- --test command_line_t --type" &
       )
     end if
   end if

--- a/test/legacy-driver.F90
+++ b/test/legacy-driver.F90
@@ -9,7 +9,7 @@ program legacy_driver
 #ifdef __GNUC__
 #if (GCC_VERSION < 140300)
   ! Internal utilities
-  use julienne_m                     ,only : command_line_t, GitHub_CI
+  use julienne_m                     ,only : command_line_t, GitHub_CI, one_image_prints
 
   ! Test modules
   use assert_test_m                  ,only :                  assert_test_t
@@ -45,7 +45,7 @@ program legacy_driver
 
   if (command_line%argument_present([character(len=len("--help"))::"--help","-h"])) stop usage
 
-  print "(a)", new_line("") // "Append '-- --help' or '-- -h' to your `fpm test` command to display usage information."
+  call one_image_prints(new_line("") // "Append '-- --help' or '-- -h' to your `fpm test` command to display usage information.")
 
   call assert_test%report(passes, tests, skips)
   call bin_test%report(passes, tests, skips)
@@ -59,11 +59,12 @@ program legacy_driver
     if (command_line%argument_present(["--test"])) then
       call command_line_test%report(passes, tests, skips)
     else
-      write(*,"(a)")  &
-      new_line("") // &
-      "To also test Julienne's command_line_t type, append the following to your fpm test command:" // &
-      new_line("") // &
-      "-- --test command_line_t --type"
+      call one_image_prints( &
+        new_line("") // &
+        "To test Julienne's command_line_t type, append the following to your fpm command:" // &
+        new_line("") // &
+        "-- --test command_line_t --type"
+      )
     end if
   end if
 
@@ -71,9 +72,10 @@ program legacy_driver
   if (this_image()==1) then
 #endif
 
-    print *
-    print '(*(a,:,g0))', "_________ In total, ",passes," of ",tests, " tests pass.  ", skips, " tests were skipped. _________"
-
+    call one_image_prints( &
+      "_____ In total, " // string_t(passes) // " of " // string_t(tests) //  " tests pass.  " // &
+      string_t(skips), " tests were skipped. _____" &
+    )
     if (passes + skips /= tests) error stop "Some executed tests failed."
 
 #if HAVE_MULTI_IMAGE_SUPPORT

--- a/test/legacy-driver.F90
+++ b/test/legacy-driver.F90
@@ -74,7 +74,7 @@ program legacy_driver
 
     call one_image_prints( &
       "_____ In total, " // string_t(passes) // " of " // string_t(tests) //  " tests pass.  " // &
-      string_t(skips), " tests were skipped. _____" &
+      string_t(skips) // " tests were skipped. _____" &
     )
     if (passes + skips /= tests) error stop "Some executed tests failed."
 

--- a/test/legacy-driver.F90
+++ b/test/legacy-driver.F90
@@ -9,7 +9,7 @@ program legacy_driver
 #ifdef __GNUC__
 #if (GCC_VERSION < 140300)
   ! Internal utilities
-  use julienne_m                     ,only : command_line_t, GitHub_CI, one_image_prints
+  use julienne_m                     ,only : command_line_t, GitHub_CI, one_image_prints, string_t
 
   ! Test modules
   use assert_test_m                  ,only :                  assert_test_t

--- a/test/logical_assertion_failure_test.F90
+++ b/test/logical_assertion_failure_test.F90
@@ -6,7 +6,7 @@
 
 program logical_assertion_failure_test
   !! Conditionally test an assertion that is hardwired to fail.
-  use julienne_m, only : call_julienne_assert_, command_line_t, operator(.equalsExpected.)
+  use julienne_m, only : call_julienne_assert_, command_line_t, operator(.equalsExpected.),one_image_prints 
   implicit none
   integer, allocatable :: array(:)
 
@@ -17,17 +17,16 @@ program logical_assertion_failure_test
 #endif
     if (.not. command_line%argument_present([character(len=len("--help"))::"--help","-h"])) then
 #ifdef RUN_FALSE_ASSERTIONS
-      if (me==1) print '(a)', new_line('') // 'Test the intentional failure of a logical assertion: ' // new_line('')
+      call one_image_prints(new_line('') // 'Test the intentional failure of a logical assertion: ' // new_line(''))
       if (allocated(array)) deallocate(array)
       call_julienne_assert(allocated(array))
 #else
-      if (me==1) then
-        print '(a)', &
+      call one_image_prints( &
           new_line('') // &
           'Skipping the test in ' // __FILE__ // '.' // new_line('') // &
           'Add the following to your fpm command to test assertion failures: --flag "-DASSERTIONS -DRUN_FALSE_ASSERTIONS"' // &
-          new_line('')
-      end if
+          new_line('') &
+      )
 #endif
     end if
   end associate

--- a/test/modules/command_line_test_m.F90
+++ b/test/modules/command_line_test_m.F90
@@ -8,6 +8,7 @@ module command_line_test_m
   use julienne_m, only : &
      command_line_t &
     ,GitHub_CI &
+    ,one_image_prints &
     ,operator(.equalsExpected.) &
     ,operator(.expect.) &
     ,string_t &
@@ -76,11 +77,12 @@ contains
         ,test_description_t(string_t("argument_present() result is .true. if a command-line argument is present")) &
       ]
       if (me==1) then
-        print "(*(a))"  &
-        ,new_line('') &
-        ,"----> Skipping the command_line_t tests in GitHub CI.", new_line('') &
-        ,"----> To test locally, append the following flags to the 'fpm test' command: -- --test command_line_t --type" &
-        ,new_line('')
+        call one_image_prints( &
+          new_line('') &
+          // "----> Skipping the command_line_t tests in GitHub CI.", new_line('') &
+          // "----> To test locally, append the following flags to the 'fpm test' command: -- --test command_line_t --type" &
+          // new_line('') &
+          )
       end if
     else if (.not. command_line%argument_present(["--test"])) then ! skip the tests if not explicitly requested
       test_descriptions = [ &
@@ -91,10 +93,11 @@ contains
         ,test_description_t(string_t("argument_present() result is .true. if a command-line argument is present")) &
       ]
       if (me==1) then
-        print "(*(a))"  &
-        ,new_line('') &
-        ,"-----> To test command_line_t, append the following to the 'fpm test' command: -- --test command_line_t --type" &
-        ,new_line('')
+        call one_image_prints( &
+          new_line('') &
+          // "-----> To test command_line_t, append the following to the 'fpm test' command: -- --test command_line_t --type" &
+          // new_line('') &
+        )
       end if
     else ! run the tests
 #if HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY

--- a/test/modules/command_line_test_m.F90
+++ b/test/modules/command_line_test_m.F90
@@ -79,7 +79,7 @@ contains
       if (me==1) then
         call one_image_prints( &
           new_line('') &
-          // "----> Skipping the command_line_t tests in GitHub CI.", new_line('') &
+          // "----> Skipping the command_line_t tests in GitHub CI." // new_line('') &
           // "----> To test locally, append the following flags to the 'fpm test' command: -- --test command_line_t --type" &
           // new_line('') &
           )


### PR DESCRIPTION
This commit replaces all`print` and non-internal `write` statements (except in `test/legacy-driver.f90`) with a call to the new `one_image_prints` subroutine to eliminate replicated output during multi-image runs.