### PR TITLE
fix(scaffold): work around gfortran/nagfor bugs

### DIFF
--- a/app/scaffold.F90
+++ b/app/scaffold.F90
@@ -9,7 +9,7 @@ program scaffold
 
   if (help_requested()) call print_usage_info_and_stop
 
-#ifndef __GNUC__
+#if (! __GNUC__) && (! NAGFOR)
   associate(subjects_file_name => command_line%flag_value("--json-file"))
     if (len(subjects_file_name) == 0) call print_usage_info_and_stop
     print '(*(a))', "Reading test subject information from " // subjects_file_name
@@ -42,6 +42,13 @@ program scaffold
       if (len(path) == 0) call print_usage_info_and_stop
       print '(*(a))', "Writing test-suite scaffolding in " // path
       call test_suite%write_driver(path // "/driver.f90")
+      associate(subjects => test_suite%test_subjects(), modules => test_suite%test_modules())
+        do i = 1, size(subjects)
+          associate(stub => test_suite%stub_file(subjects(i)))
+            call stub%write_lines(path // "/" // modules(i) // ".f90")
+          end associate
+        end do
+      end associate
     end associate
   end block
 #endif

--- a/src/julienne/julienne_test_suite_s.F90
+++ b/src/julienne/julienne_test_suite_s.F90
@@ -152,7 +152,6 @@ contains
     write(file_unit, '(a)') "  use julienne_m, only : test_fixture_t, test_harness_t"
 
     block
-      type(string_t), allocatable :: test_modules(:)
       type(string_t) use_statement
       test_modules = self%test_modules() ! GCC 14.2 blocks the use of an association
       test_types = self%test_types()     ! GCC 14.2 blocks the use of an association
@@ -166,7 +165,6 @@ contains
     write(file_unit, '(a)') "  associate(test_harness => test_harness_t([ &"
 
     block
-      type(string_t), allocatable :: test_types(:)
       type(string_t) fixture_constructor
       test_types   = self%test_types()   ! GCC 14.2 blocks the use of an association
       fixture_constructor =  "     test_fixture_t(" // test_types(1) // "()) &"


### PR DESCRIPTION
Julienne's `scaffold` program now works correctly with `flang-new`, `nagfor`, `gfortran`, and `ifx`.