### PR TITLE
Feature: integer(int64) relational operators for test_diagnosis_t operands

### DIFF
--- a/src/julienne/julienne_test_diagnosis_m.F90
+++ b/src/julienne/julienne_test_diagnosis_m.F90
@@ -6,7 +6,8 @@
 module julienne_test_diagnosis_m
   !! Define abstractions, defined operations, and procedures for writing correctness checks
   use julienne_string_m, only : string_t
-  use iso_c_binding, only : c_size_t, c_ptr
+  use iso_fortran_env, only : int64
+  use iso_c_binding, only : c_ptr
   implicit none
 
   private
@@ -256,9 +257,9 @@ module julienne_test_diagnosis_m
       type(test_diagnosis_t) test_diagnosis
     end function
 
-    elemental module function equals_expected_integer_c_size_t(actual, expected) result(test_diagnosis)
+    elemental module function equals_expected_int64(actual, expected) result(test_diagnosis)
       implicit none
-      integer(c_size_t), intent(in) :: actual, expected
+      integer(int64), intent(in) :: actual, expected
       type(test_diagnosis_t) test_diagnosis
     end function
 
@@ -310,6 +311,12 @@ module julienne_test_diagnosis_m
       type(test_diagnosis_t) test_diagnosis
     end function
 
+    elemental module function less_than_int64(actual, expected_ceiling) result(test_diagnosis)
+      implicit none
+      integer(int64), intent(in) :: actual, expected_ceiling
+      type(test_diagnosis_t) test_diagnosis
+    end function
+
   end interface
 
   interface operator(.lessThanOrEqualTo.)
@@ -317,6 +324,12 @@ module julienne_test_diagnosis_m
     elemental module function less_than_or_equal_to_integer(actual, expected_max) result(test_diagnosis)
       implicit none
       integer, intent(in) :: actual, expected_max
+      type(test_diagnosis_t) test_diagnosis
+    end function
+
+    elemental module function less_than_or_equal_to_int64(actual, expected_max) result(test_diagnosis)
+      implicit none
+      integer(int64), intent(in) :: actual, expected_max
       type(test_diagnosis_t) test_diagnosis
     end function
 
@@ -336,12 +349,14 @@ module julienne_test_diagnosis_m
 
   interface operator(.isAtMost.)
     module procedure less_than_or_equal_to_integer
+    module procedure less_than_or_equal_to_int64
     module procedure less_than_or_equal_to_real
     module procedure less_than_or_equal_to_double_precision
   end interface
 
   interface operator(.isAtLeast.)
     module procedure greater_than_or_equal_to_integer
+    module procedure greater_than_or_equal_to_int64
     module procedure greater_than_or_equal_to_real
     module procedure greater_than_or_equal_to_double_precision
   end interface
@@ -414,6 +429,12 @@ module julienne_test_diagnosis_m
       type(test_diagnosis_t) test_diagnosis
     end function
 
+    elemental module function greater_than_or_equal_to_int64(actual, expected_min) result(test_diagnosis)
+      implicit none
+      integer(int64), intent(in) :: actual, expected_min
+      type(test_diagnosis_t) test_diagnosis
+    end function
+
     elemental module function greater_than_or_equal_to_real(actual, expected_min) result(test_diagnosis)
       implicit none
       real, intent(in) :: actual, expected_min
@@ -445,6 +466,12 @@ module julienne_test_diagnosis_m
     elemental module function greater_than_integer(actual, expected_floor) result(test_diagnosis)
       implicit none
       integer, intent(in) :: actual, expected_floor
+      type(test_diagnosis_t) test_diagnosis
+    end function
+
+    elemental module function greater_than_int64(actual, expected_floor) result(test_diagnosis)
+      implicit none
+      integer(int64), intent(in) :: actual, expected_floor
       type(test_diagnosis_t) test_diagnosis
     end function
 

--- a/src/julienne/julienne_test_diagnosis_s.F90
+++ b/src/julienne/julienne_test_diagnosis_s.F90
@@ -294,7 +294,7 @@ contains
 
   end procedure
 
-  module procedure equals_expected_integer_c_size_t
+  module procedure equals_expected_int64
 
     if (actual == expected) then
       test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
@@ -390,7 +390,31 @@ contains
 
   end procedure
 
+  module procedure less_than_int64
+
+    if (actual < expected_ceiling) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed = .false. &
+        ,diagnostics_string = "The value " // string_t(actual) // " was expected to be less than " // string_t(expected_ceiling) &
+      )
+    end if
+
+  end procedure
+
   module procedure less_than_or_equal_to_integer
+
+    if (actual <= expected_max) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed = .false. &
+        ,diagnostics_string = "The value " // string_t(actual) // " was expected to be less than or equal to " // string_t(expected_max) &
+      )
+    end if
+
+  end procedure
+
+  module procedure less_than_or_equal_to_int64
 
     if (actual <= expected_max) then
       test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
@@ -427,6 +451,18 @@ contains
   end procedure
 
   module procedure greater_than_or_equal_to_integer
+
+    if (actual >= expected_min) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed = .false. &
+        ,diagnostics_string = "The value " // string_t(actual) // " was expected to be greater than or equal to " // string_t(expected_min) &
+      )
+    end if
+
+  end procedure
+
+  module procedure greater_than_or_equal_to_int64
 
     if (actual >= expected_min) then
       test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
@@ -487,6 +523,18 @@ contains
   end procedure
 
   module procedure greater_than_integer
+
+    if (actual > expected_floor) then
+      test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")
+    else
+      test_diagnosis = test_diagnosis_t(test_passed = .false. &
+        ,diagnostics_string = "The value " // string_t(actual) // " was expected to be greater than " // string_t(expected_floor) &
+      )
+    end if
+
+  end procedure
+
+  module procedure greater_than_int64
 
     if (actual > expected_floor) then
       test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="")

--- a/test/modules/test_diagnosis_test_m.F90
+++ b/test/modules/test_diagnosis_test_m.F90
@@ -31,6 +31,7 @@ module test_diagnosis_test_m
     ,operator(.greaterThan.) &
     ,operator(.isAtLeast.)
   use iso_c_binding, only : c_ptr, c_loc, c_bool
+  use iso_fortran_env, only : int64
   implicit none
 
   private
@@ -72,6 +73,7 @@ contains
       ,test_description_t("construction from the type(c_ptr) expression 'p .equalsExpected. q'"                                , usher(check_equals_c_ptr)) &
       ,test_description_t("construction from the string_t expression 'a .equalsExpected. b'"                                   , usher(check_equals_string)) &
       ,test_description_t("construction from the integer expression 'i .equalsExpected. j'"                                    , usher(check_equals_integer)) &
+      ,test_description_t("construction from integer(int64) relational operators"                                              , usher(check_int64_comparisons)) &
       ,test_description_t("construction from the integer expression 'i .lessThan. j"                                           , usher(check_less_than_integer)) &
       ,test_description_t("construction from the integer expression '[i,j] .lessThanOrEqualTo. k"                              , usher(check_less_than_or_equal_to_integer)) &
       ,test_description_t("construction from the integer expression 'i .greaterThan. j"                                        , usher(check_greater_than_integer)) &
@@ -180,6 +182,16 @@ contains
     type(test_diagnosis_t) test_diagnosis
     real, parameter :: expected_ceiling = 1.
     test_diagnosis = 0. .lessThan. expected_ceiling
+  end function
+
+  function check_int64_comparisons() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    integer(int64), parameter :: zero = 0_int64, one = 1_int64, two = 2_int64
+    test_diagnosis = &
+             ( zero .lessThan.    one) &
+      .also. ( one  .isAtLeast.   one) &
+      .also. (-one  .isAtMost.   zero) &
+      .also. ( two  .greaterThan. one)
   end function
 
   function check_less_than_double() result(test_diagnosis)


### PR DESCRIPTION
This commit adds support for `integer(int64)` operands for the following operators:

  - `.isAtleast.`
  - `.isAtMost.`
  - `.lessThan.`
  - `.greaterThan.`

To keep the operator implementations uniform, this commit also replaces one `integer(c_size_t)` operator with an `integer(int64)`, which is equivalent with every compiler tested.  Also, `int64` predates `c_size_t` and therefore is more likely to be supported by older compiler versions. Fortran 2008 introduced `int64`. Fortran 2018 introduced `c_size_t`.