### PR TITLE
Fixes #144

### DIFF
--- a/src/julienne/julienne_test_harness_s.F90
+++ b/src/julienne/julienne_test_harness_s.F90
@@ -4,7 +4,7 @@
 #include "language-support.F90"
 
 submodule(julienne_test_harness_m) julienne_test_harness_s
-  use iso_fortran_env, only : int64, real64
+  use iso_fortran_env, only : int64, real64, output_unit
   use julienne_command_line_m, only : command_line_t
   use julienne_string_m, only : string_t
   implicit none
@@ -47,8 +47,12 @@ contains
           print *
           print '(*(a,:,i0))', "_____ ", passes, " of ", tests, " tests passed. ", skips, " tests were skipped _____"
           print *
+          flush(output_unit)
         end if
-        if (passes + skips /= tests .and. me==1) error stop "Some tests failed."
+#if HAVE_MULTI_IMAGE_SUPPORT
+        sync all
+#endif
+        if (passes + skips /= tests) error stop "Some tests failed."
       end associate
 
     end procedure


### PR DESCRIPTION
This commit ensures that
1. Any image that detects a test failure will execute `error stop`.
2. A `sync all` precedes the `error stop` so image 1 will finish reporting results before any error termination occurs.
3. A `flush` on image 1 precedes the `sync all` to make the report output available by processor-dependent mechanisms.