### PR TITLE
Fix aggregate_vector_diagnosis description indent handling

### DIFF
--- a/src/julienne/julienne_test_diagnosis_s.F90
+++ b/src/julienne/julienne_test_diagnosis_s.F90
@@ -95,7 +95,12 @@ contains
       integer i
       allocate(array(size(diagnoses)))
       do i = 1, size(diagnoses)
-        array(i) = string_t(new_line_indent // diagnoses(i)%diagnostics_string_)
+        if (diagnoses(i)%diagnostics_string_(1:1) == new_line('')) then
+          ! don't prepend a another newline if the string already begins with one
+          array(i) = diagnoses(i)%diagnostics_string_
+        else 
+          array(i) = string_t(new_line_indent // diagnoses(i)%diagnostics_string_)
+        end if
       end do
       diagnosis = test_diagnosis_t( &
          test_passed = all(diagnoses%test_passed_) &
@@ -119,7 +124,12 @@ contains
     integer i
     allocate(array(size(diagnoses)))
     do i = 1, size(diagnoses)
-      array(i) = string_t(new_line_indent // diagnoses(i)%diagnostics_string_)
+      if (diagnoses(i)%diagnostics_string_(1:1) == new_line('')) then
+        ! don't prepend a another newline if the string already begins with one
+        array(i) = diagnoses(i)%diagnostics_string_
+      else 
+        array(i) = string_t(new_line_indent // diagnoses(i)%diagnostics_string_)
+      end if
     end do
     diagnosis = test_diagnosis_t( &
        test_passed = all(diagnoses%test_passed_) &


### PR DESCRIPTION
Fix a bug in aggregate_vector_diagnosis that breaks Julienne diagnostic string aggregation with `.also.`.

Currently given an incremental diagnosis pattern like this:
```fortran
diag = .true.
diag = .diag. .also. .false. // "whatever"
do i=1,100
  diag = .diag. .also. .true.
end do
```
During the loop the code in aggregate_vector_diagnosis will prepend 100 `new_line_indent` strings into the diagnosis string (ie 100 blank lines), even though there was only one actual failure.

Fundamentally the problem is that a `new_line_indent` is being prepended each time `aggregate_vector_diagnosis` is called with a failing argument, even if the failing diagnosis was the outcome of a previous call to `aggregate_vector_diagnosis` that already prepended a new line.

The surgical solution in this PR prevents this defect. As a side-benefit it also provides nicer behavior if the client has formatted their own output line and already inserted a line break, eg:
```fortran
diag = test_diagnosis_t(.false.,new_line('') // "  I formatted this line myself!")
```