### PR TITLE
Documentation: Replace `flang-new` with `flang`

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,15 +186,15 @@ Building and Testing
 --------------------
 With the Fortran Package Manager ([`fpm`]) installed and in your `PATH`, the
 commands in the table below will build and run the Julienne test suite.  With
-`fpm` versions higher than 0.12.0, `flang-new` can be replaced with `flang`.
+`fpm` versions lower than 0.13.0, replace `flang` with `flang-new` in the commands below.
 For additional information on setting up parallel builds with LLVM, please see
 [parallel-testing-with-flang.md](./doc/parallel-testing-with-flang.md).
 
-Compiler/Runtime  |Tested Versions|Run Type|Example build/test commands (parallel examples use 2 images)
+Vendor/Runtime    |Tested Versions|Run Type|Example build/test commands (parallel examples use 2 images)
 ------------------|---------------|--------|------------------------------------------------------------
-LLVM/[Caffeine]   |22.0.0git      |parallel|`fpm test --compiler flang-new --flag "-O3 -DHAVE_MULTI_IMAGE_SUPPORT -fcoarray" --link-flag "-lcaffeine -lgasnet-smp-seq -L<caffeine-path> -L<gasnet-path>"`
-LLVM              |20-22          |serial  |`fpm test --compiler flang-new --flag -O3`
-LLVM              |19             |serial  |`fpm test --compiler flang-new --flag "-O3 -mmlir -allow-assumed-rank"`
+LLVM/[Caffeine]   |22.0.0git      |parallel|`fpm test --compiler flang --flag "-O3 -DHAVE_MULTI_IMAGE_SUPPORT -fcoarray" --link-flag "-lcaffeine -lgasnet-smp-seq -L<caffeine-path> -L<gasnet-path>"`
+LLVM              |20-22          |serial  |`fpm test --compiler flang --flag -O3`
+LLVM              |19             |serial  |`fpm test --compiler flang --flag "-O3 -mmlir -allow-assumed-rank"`
 NAG               |7.2, Build 7235|parallel|`NAGFORTRAN_NUM_IMAGES=2 fpm test --compiler nagfor --flag "-fpp -O3 -coarray"`
 Intel             |2025.2.{0-1}   |parallel|`FOR_COARRAY_NUM_IMAGES=2 fpm test --compiler ifx --flag "-fpp -O3 -coarray" --profile release`
 GCC/[OpenCoarrays]|14-15          |serial  |`fpm test --compiler gfortran --profile release`

--- a/demo/README.md
+++ b/demo/README.md
@@ -88,10 +88,11 @@ Running the demonstration tests
 With the Fortran Package Manager (`fpm`) installed, please set the `demo`
 subdirectory as your present working directory in a shell.  Then run the
 demonstration test suite using the command below for your compiler.
+With `fpm` versions lower than 0.13.0, replace `flang` with `flang-new` below.
 
-|Vendor | Version(s) Tested                   | Example shell command                            |
+|Vendor | Version(s) Tested       | Example shell command                            |
 |-------|-------------------------|--------------------------------------------------|
-|LLVM   | 20-21                   | `fpm test --compiler flang-new --flag "-O3"`     |
+|LLVM   | 20-21                   | `fpm test --compiler flang --flag "-O3"`         |
 |GCC    | 13-15<sup>1</sup>       | `fpm test --compiler gfortran --profile release` |
 |NAG    | 7.2 Build 7235          | `fpm test --compiler nagfor --flag "-O3 -fpp"`   |
 |Intel  | 2025.2.1 Build 20250806 | `fpm test --compiler ifx --flag "-fpp -O3"`      |
@@ -114,7 +115,7 @@ Please run following command in a `bash` or `zsh` shell with Julienne's root
 directory as your present working directory:
 ```
 fpm run scaffold \
-  --compiler flang-new \
+  --compiler flang \ # with `fpm` 0.12.0 or older, replace "flang" with "flang-new"
   -- --json-file demo/test-suite.json \
   --suite-path demo/test
 ```

--- a/doc/parallel-testing-with-flang.md
+++ b/doc/parallel-testing-with-flang.md
@@ -33,7 +33,7 @@ cd ..
 where angular brackets denote variables to replace with your chosen value.
 
 ### Build Caffeine and GASNet
-An `.install.sh` invocation of the form below _should_ install Caffeine and
+An `install.sh` invocation of the form below _should_ install Caffeine and
 GASNet in `<caffeine-install-path>/lib`.
 ```bash
 git clone -b 0.7.0 https://github.com/BerkeleyLab/caffeine.git

--- a/doc/parallel-testing-with-flang.md
+++ b/doc/parallel-testing-with-flang.md
@@ -55,7 +55,7 @@ Then move `libcaffeine.a` to the `<caffeine-install-path>/lib` directory.
 ### Build and Test Julienne
 With `fpm` versions lower than 0.13.0, replace `flang` with `flang-new` below.
 ```
-git clone -b 3.2.0 https://github.com/BerkeleyLab/julienne.git
+git clone -b 3.6.1 https://github.com/BerkeleyLab/julienne.git
 cd julienne
 fpm test \
   --compiler flang \

--- a/doc/parallel-testing-with-flang.md
+++ b/doc/parallel-testing-with-flang.md
@@ -5,7 +5,7 @@ LLVM Flang 22 supports the native Fortran parallel programming model used by
 Julienne: features that enable launching multiple images, which are instances
 of a program.  As of this writing, "Flang 22" refers to the main branch of 
 [llvm-project](https://github.com/llvm/llvm-project), which when built from
-source, responds to `flang-new --version` with text that includes `22.0.0git`.
+source, responds to `flang --version` with text that includes `22.0.0git`.
 
 To launch multi-image runs, Flang generates calls to the Parallel Runtime
 Interface for Fortran [(PRIF)](https://go.lbl.gov/prif).  Using these features
@@ -38,7 +38,7 @@ GASNet in `<caffeine-install-path>/lib`.
 ```bash
 git clone -b 0.6.0 https://github.com/BerkeleyLab/caffeine.git
 cd caffeine
-FC=<llvm-install-path>/bin/flang-new \
+FC=<llvm-install-path>/bin/flang \
  CC=<llvm-install-path>/bin/clang \
  CXX=<llvm-install-path>/bin/clang++ \
  ./install.sh --prefix=<caffeine-install-path>
@@ -53,11 +53,12 @@ find build -name libcaffeine.a
 Then move `libcaffeine.a` to the `<caffeine-install-path>/lib` directory.
 
 ### Build and Test Julienne
+With `fpm` versions lower than 0.13.0, replace `flang` with `flang-new` below.
 ```
 git clone -b 3.2.0 https://github.com/BerkeleyLab/julienne.git
 cd julienne
 fpm test \
-  --compiler flang-new \
+  --compiler flang \
   --flag "-O3 -DHAVE_MULTI_IMAGE_SUPPORT -fcoarray" \
   --link-flag "-lcaffeine -lgasnet-smp-seq -L<caffeine-install-path>/lib"
 ```

--- a/doc/parallel-testing-with-flang.md
+++ b/doc/parallel-testing-with-flang.md
@@ -36,7 +36,7 @@ where angular brackets denote variables to replace with your chosen value.
 An `.install.sh` invocation of the form below _should_ install Caffeine and
 GASNet in `<caffeine-install-path>/lib`.
 ```bash
-git clone -b 0.6.0 https://github.com/BerkeleyLab/caffeine.git
+git clone -b 0.7.0 https://github.com/BerkeleyLab/caffeine.git
 cd caffeine
 FC=<llvm-install-path>/bin/flang \
  CC=<llvm-install-path>/bin/clang \


### PR DESCRIPTION
`fpm` 0.13.0 recognizes `flang` as LLVM `flang`, which eliminates the need to use the `flang-new` alias.  This PR replaces `flang-new` with `flang` in the Julienne documentation and adds notes recommending the use of `flang-new` with older `fpm` versions.