### PR TITLE
Feature: pure stop_and_print subroutine 

### DIFF
--- a/src/julienne/julienne_multi_image_m.F90
+++ b/src/julienne/julienne_multi_image_m.F90
@@ -31,7 +31,7 @@ module julienne_multi_image_m
       integer, intent(in), optional :: result_image
     end subroutine
 
-    module subroutine internal_error_stop(stop_code_char)
+    module pure subroutine internal_error_stop(stop_code_char)
       implicit none
       character(len=*), intent(in) :: stop_code_char
     end subroutine
@@ -78,7 +78,7 @@ module julienne_multi_image_m
     procedure(julienne_co_sum_integer_interface), pointer :: julienne_co_sum_integer
 
     abstract interface
-      subroutine julienne_error_stop_interface(stop_code_char)
+      pure subroutine julienne_error_stop_interface(stop_code_char)
         implicit none
         character(len=*), intent(in) :: stop_code_char
       end subroutine

--- a/src/julienne/julienne_stop_and_print_m.F90
+++ b/src/julienne/julienne_stop_and_print_m.F90
@@ -1,0 +1,20 @@
+! Copyright (c), The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
+
+module julienne_stop_and_print_m
+  !! Define a pure subroutine subroutine that prints string_t objects/arrays
+  use julienne_string_m, only : string_t
+  implicit none
+  
+  private
+  public :: stop_and_print
+
+contains
+
+  pure subroutine stop_and_print(message)
+    implicit none
+    type(string_t), intent(in) :: message
+    error stop message%string()
+  end subroutine
+  
+end module

--- a/src/julienne/julienne_stop_and_print_m.F90
+++ b/src/julienne/julienne_stop_and_print_m.F90
@@ -4,6 +4,7 @@
 module julienne_stop_and_print_m
   !! Define a pure subroutine that terminates with an ERROR STOP message from a string_t
   use julienne_string_m, only : string_t
+  use julienne_multi_image_m, only : internal_error_stop
   implicit none
   
   private

--- a/src/julienne/julienne_stop_and_print_m.F90
+++ b/src/julienne/julienne_stop_and_print_m.F90
@@ -2,7 +2,7 @@
 ! Terms of use are as specified in LICENSE.txt
 
 module julienne_stop_and_print_m
-  !! Define a pure subroutine subroutine that prints string_t objects/arrays
+  !! Define a pure subroutine that terminates with an ERROR STOP message from a string_t
   use julienne_string_m, only : string_t
   implicit none
   

--- a/src/julienne/julienne_stop_and_print_m.F90
+++ b/src/julienne/julienne_stop_and_print_m.F90
@@ -14,7 +14,7 @@ contains
   pure subroutine stop_and_print(message)
     implicit none
     type(string_t), intent(in) :: message
-    error stop message%string()
+    call internal_error_stop(message%string())
   end subroutine
   
 end module

--- a/src/julienne/julienne_test_m.F90
+++ b/src/julienne/julienne_test_m.F90
@@ -19,6 +19,8 @@ module julienne_test_m
   type, abstract :: test_t
     !! Facilitate testing and test reporting
 
+    integer :: dummy = 0 ! this is to ensure the type is default-initialized, to eliminate warnings
+
   contains
     procedure(subject_interface), nopass, deferred :: subject 
     procedure(results_interface), nopass, deferred :: results

--- a/src/julienne_m.F90
+++ b/src/julienne_m.F90
@@ -9,6 +9,7 @@ module julienne_m
   use julienne_file_m, only : file_t
   use julienne_formats_m, only : separated_values, csv
   use julienne_github_ci_m, only : github_ci
+  use julienne_stop_and_print_m, only : stop_and_print
   use julienne_string_m, only : string_t, array_of_strings &
     ,operator(.cat.) &
     ,operator(.csv.) &

--- a/test/modules/multi_image_test_m.F90
+++ b/test/modules/multi_image_test_m.F90
@@ -173,7 +173,7 @@ contains
 #   endif
   end subroutine
 
-  subroutine julienne_callback_error_stop(stop_code_char)
+  pure subroutine julienne_callback_error_stop(stop_code_char)
     implicit none
     character(len=*), intent(in) :: stop_code_char
 

--- a/test/modules/test_description_test_m.F90
+++ b/test/modules/test_description_test_m.F90
@@ -51,11 +51,11 @@ contains
 
     test_diagnosis = test_diagnosis_t(  &
        test_passed = test_description_t("foo", tautology_ptr) == test_description_t(string_t("foo"), tautology_ptr) &
-      ,diagnostics_string= 'test_description_t("foo", tautology_ptr) /= test_description_t(string_t("foo"), tautology_ptr)'&
+      ,diagnostics_string= 'test_description_t("foo", tautology_ptr) /= test_description_t(string_t("foo"), tautology_ptr)' &
     )
     test_diagnosis = test_diagnosis_t(  &
        test_passed = .not. (test_description_t("foo", tautology_ptr) == test_description_t("foo")) &
-      ,diagnostics_string= 'test_description_t("foo", tautology_ptr) == test_description_t("foo")'&
+      ,diagnostics_string= 'test_description_t("foo", tautology_ptr) == test_description_t("foo")' &
     )
 #if HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
     test_diagnosis = test_diagnosis .also. test_diagnosis_t( &
@@ -69,19 +69,19 @@ contains
 #endif
     test_diagnosis = test_diagnosis .also. test_diagnosis_t( &
        test_passed = test_description_t("foo", tautology_ptr) == test_description_t("foo", usher(tautology)) &
-      ,diagnostics_string= 'test_description_t("foo", tautology_ptr) /= test_description_t("foo", usher(tautology))'&
+      ,diagnostics_string= 'test_description_t("foo", tautology_ptr) /= test_description_t("foo", usher(tautology))' &
     )
     test_diagnosis = test_diagnosis .also. test_diagnosis_t( &
        test_passed = test_description_t("foo", tautology_ptr) == test_description_t("foo", c_funloc(tautology_ptr)) &
-      ,diagnostics_string= 'test_description_t("foo", tautology_ptr) /= test_description_t("foo", c_funloc(tautology))'&
+      ,diagnostics_string= 'test_description_t("foo", tautology_ptr) /= test_description_t("foo", c_funloc(tautology))' &
     )
     test_diagnosis = test_diagnosis .also. test_diagnosis_t( &
        test_passed = test_description_t(string_t("foo"), tautology_ptr) == test_description_t(string_t("foo"), usher(tautology)) &
-      ,diagnostics_string= 'test_description_t(string_t("foo"), tautology_ptr) /= test_description_t(string_t("foo"), usher(tautology))'&
+      ,diagnostics_string= 'test_description_t(string_t("foo"), tautology_ptr) /= test_description_t(string_t("foo"), usher(tautology))' &
     )
     test_diagnosis = test_diagnosis .also. test_diagnosis_t( &
        test_passed = test_description_t(string_t("foo"), tautology_ptr) == test_description_t(string_t("foo"), c_funloc(tautology_ptr)) &
-      ,diagnostics_string= 'test_description_t(string_t("foo"), tautology_ptr) /= test_description_t(string_t("foo"), c_funloc(tautology))'&
+      ,diagnostics_string= 'test_description_t(string_t("foo"), tautology_ptr) /= test_description_t(string_t("foo"), c_funloc(tautology))' &
     )
   contains
     type(test_diagnosis_t) function tautology()

--- a/test/test_stop_and_print.F90
+++ b/test/test_stop_and_print.F90
@@ -31,7 +31,7 @@ program stop_and_print_in_pure_procedure
 contains
 
   pure subroutine pure_subroutine
-    integer, parameter :: array(4) = [1,2,3,4]
+    integer, parameter :: array(*) = [1,2,3,4]
     call stop_and_print("array = " // .csv. string_t(array))
   end subroutine
 

--- a/test/test_stop_and_print.F90
+++ b/test/test_stop_and_print.F90
@@ -16,7 +16,7 @@ program stop_and_print_in_pure_procedure
 #endif
     if (.not. command_line%argument_present([character(len=len("--help"))::"--help","-h"])) then
 #if TEST_INTENTIONAL_FAILURE && ASSERTIONS
-      if (me==1) print '(a)', new_line('') // 'Test the intentional failure of an idiomatic assertion: ' // new_line('')
+      if (me==1) print '(a)', new_line('') // 'Test the intentional failure of stop_and_print in a pure procedure: ' // new_line('')
       call pure_subroutine
 #else
       if (me==1) print '(a)',  &
@@ -31,7 +31,7 @@ program stop_and_print_in_pure_procedure
 contains
 
   pure subroutine pure_subroutine
-    integer, parameter :: array(*) = [1,2,3,4]
+    integer, parameter :: array(4) = [1,2,3,4]
     call stop_and_print("array = " // .csv. string_t(array))
   end subroutine
 

--- a/test/test_stop_and_print.F90
+++ b/test/test_stop_and_print.F90
@@ -1,0 +1,38 @@
+! Copyright (c) 2024-2025, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in LICENSE.txt
+
+#include "julienne-assert-macros.h"
+#include "language-support.F90"
+
+program stop_and_print_in_pure_procedure
+  !! Conditionally test printing via error termination inside a pure procedure
+  use julienne_m, only : command_line_t, string_t, operator(.csv.), stop_and_print
+  implicit none
+
+#if HAVE_MULTI_IMAGE_SUPPORT
+  associate(command_line => command_line_t(), me => this_image())
+#else
+  associate(command_line => command_line_t(), me => 1)
+#endif
+    if (.not. command_line%argument_present([character(len=len("--help"))::"--help","-h"])) then
+#if TEST_INTENTIONAL_FAILURE && ASSERTIONS
+      if (me==1) print '(a)', new_line('') // 'Test the intentional failure of an idiomatic assertion: ' // new_line('')
+      call pure_subroutine
+#else
+      if (me==1) print '(a)',  &
+           new_line('') // &
+           'Skipping the test in ' // __FILE__ // '.' // new_line('') // &
+           'Add the following to your fpm command to test the stop_and_print: --flag "-DASSERTIONS -DTEST_INTENTIONAL_FAILURE"' // &
+           new_line('')
+#endif
+    end if
+  end associate
+
+contains
+
+  pure subroutine pure_subroutine
+    integer, parameter :: array(*) = [1,2,3,4]
+    call stop_and_print("array = " // .csv. string_t(array))
+  end subroutine
+
+end program


### PR DESCRIPTION
New in this PR
--------------
1. A pure `stop_and_print` subroutine and 
2. A corresponding unit test.

 The new subroutine facilitates printing `string_t` objects, including the results of `string_t` expressions, during error termination.  

Use Case
----------
Julienne currently provides diagnostic information when assertions are enabled and an assertion fails.  An assertion effectively states an expectation about values or relationships between values.  When such an expectation is not readily at hand, one can force a print with an assertion hardwired for failure:
```
call_jullienne_assert( .expect. .false. // (.csv. ("array = " // string_t( [1,2,3,4] ) ))
```
This approach is cumbersome and non-obvious for new users.  The new `stop_and_print` offers a simpler, more obvious alternative:
```
call stop_and_print( .csv. ("array = " // string_t( [1,2,3,4] ) ))
```
The new alternative is most useful during debugging sessions when one wants to temporarily insert a print statement deep in a sequence of `pure` procedure invocations, where printing is precluded and temporarily removing the `pure` attribute from each procedure in the sequence is time-consuming and tedious.