### PR TITLE
[NO REVIEW] CI: Add coverage for all examples and command_line_t, fix #162

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,13 +260,13 @@ jobs:
 
     - name: Build and Test (Assertions OFF)
       run: |
-        fpm test ${FPM_FLAGS} --flag "$FFLAGS"
+        fpm test ${FPM_FLAGS} --target driver --flag "$FFLAGS" -- --test command_line_t --type
 
     - name: Build and Test (Assertions ON)
       env:
         FPM_FLAGS: ${{ env.FPM_FLAGS }} --flag -DASSERTIONS
       run: |
-        fpm test ${FPM_FLAGS} --flag "$FFLAGS"
+        fpm test ${FPM_FLAGS} --target driver --flag "$FFLAGS" -- --test command_line_t --type
 
     - name: Test w/ Parallel Callbacks
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,11 @@ jobs:
           # https://hub.docker.com/r/intel/oneapi-toolkit/tags
           - os: ubuntu-24.04
             compiler: ifx
+            version: latest-coarray
+            container: intel/oneapi-toolkit:latest
+
+          - os: ubuntu-24.04
+            compiler: ifx
             version: latest
             container: intel/oneapi-toolkit:latest
 
@@ -213,10 +218,15 @@ jobs:
           echo "FPM_FC=flang-new" >> "$GITHUB_ENV"
         elif test "$FC" = "ifx" ; then
           echo "FPM_FC=ifx" >> "$GITHUB_ENV"
-          echo "FFLAGS=-coarray -fpp -g -traceback $FFLAGS" >> "$GITHUB_ENV"
-          echo "FOR_COARRAY_NUM_IMAGES=4" >> "$GITHUB_ENV"
-          : echo "FOR_COARRAY_DEBUG_STARTUP=1" >> "$GITHUB_ENV"
-          : echo "FOR_COARRAY_MPI_VERBOSE=1" >> "$GITHUB_ENV"
+          if [[ "$COMPILER_VERSION" = "latest-coarray" ]] ; then
+            echo "FOR_COARRAY_NUM_IMAGES=4" >> "$GITHUB_ENV"
+            echo "FFLAGS=-coarray -fpp -g -traceback $FFLAGS" >> "$GITHUB_ENV"
+            #echo "FOR_COARRAY_MPI_VERBOSE=1" >> "$GITHUB_ENV"
+            #echo "FOR_COARRAY_DEBUG_STARTUP=1" >> "$GITHUB_ENV"
+          else
+            # issue #162: ifx coarray support is usually disabled because it hides runtime failures
+            echo "FFLAGS=-DHAVE_MULTI_IMAGE_SUPPORT=0 -fpp -g -traceback $FFLAGS" >> "$GITHUB_ENV"
+          fi
         elif test "$FC" = "lfortran" ; then
           echo "FPM_FC=lfortran" >> "$GITHUB_ENV"
           echo "FFLAGS=--cpp --separate-compilation --realloc-lhs-arrays $FFLAGS" >> "$GITHUB_ENV"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,6 +278,21 @@ jobs:
       run: |
         fpm test ${FPM_FLAGS} --target driver --flag "$FFLAGS" -- --test command_line_t --type
 
+    - name: Run Examples (Assertions ON)
+      env:
+        FPM_FLAGS: ${{ env.FPM_FLAGS }} --flag -DASSERTIONS
+      run: |
+        fpm run --example create-markdown-table ${FPM_FLAGS} --flag "$FFLAGS"  2>&1 | tee output
+          grep -q "|c_size_t|c_int64_t|c_intptr_t|" output
+        fpm run --example get-command-line-flag-value ${FPM_FLAGS} --flag "$FFLAGS" -- --foo bar 2>&1 | tee output
+          grep -q "foo=bar" output
+        fpm run --example check-for-command-line-argument ${FPM_FLAGS} --flag "$FFLAGS" -- --foo bar 2>&1 | tee output
+          grep -q "not present" output
+        ( set +e
+          fpm run --example assertions ${FPM_FLAGS} --flag "$FFLAGS"  2>&1 | tee output
+          test ${PIPESTATUS[0]} > 0 && grep -q "expected 2; actual value is 1" output
+        )
+
     - name: Test w/ Parallel Callbacks
       env:
         FPM_FLAGS: ${{ env.FPM_FLAGS }} --flag -DJULIENNE_PARALLEL_CALLBACKS --flag -DTEST_PARALLEL_CALLBACKS

--- a/example/strings/create-markdown-table.F90
+++ b/example/strings/create-markdown-table.F90
@@ -68,6 +68,8 @@ contains
         compiler = string_t("flang")
       else if (index(compiler_identity, "Intel") /= 0) then
         compiler = string_t("ifx")
+      else if (index(compiler_identity, "LFortran") /= 0) then
+        compiler = string_t("lfortran")
       else
 #if (! defined(__GFORTRAN__)) || (GCC_VERSION > 140000)
           error stop "unrecognized compiler: " // compiler_identity

--- a/test/modules/command_line_test_m.F90
+++ b/test/modules/command_line_test_m.F90
@@ -7,7 +7,6 @@ module command_line_test_m
   !! Verify object pattern asbtract parent
   use julienne_m, only : &
      command_line_t &
-    ,GitHub_CI &
     ,operator(.equalsExpected.) &
     ,operator(.expect.) &
     ,string_t &
@@ -50,23 +49,7 @@ contains
     associate(me => 1)
 #endif
 
-    skip_all_tests_if_running_github_ci: &
-    if (GitHub_CI()) then
-      test_descriptions = [ &
-         test_description_t(string_t("flag_value() result is the value passed after a command-line flag")) &
-        ,test_description_t(string_t("flag_value() result is an empty string if command-line flag value is missing")) &
-        ,test_description_t(string_t("flag_value() result is an empty string if command-line flag is missing")) &
-        ,test_description_t(string_t("argument_present() result is .false. if a command-line argument is missing")) &
-        ,test_description_t(string_t("argument_present() result is .true. if a command-line argument is present")) &
-      ]
-      if (me==1) then
-        print '(a)', &
-          new_line('') &
-          // "----> Skipping the command_line_t tests in GitHub CI." // new_line('') &
-          // "----> To test locally, append the following flags to the 'fpm test' command: -- --test command_line_t --type" &
-          // new_line('')
-      end if
-    else if (.not. command_line%argument_present(["--test"])) then ! skip the tests if not explicitly requested
+    if (.not. command_line%argument_present(["--test"])) then ! skip the tests if not explicitly requested
       test_descriptions = [ &
          test_description_t(string_t("flag_value() result is the value passed after a command-line flag")) &
         ,test_description_t(string_t("flag_value() result is an empty string if command-line flag value is missing")) &
@@ -88,7 +71,7 @@ contains
         ,test_description_t(string_t("argument_present() result is .false. if a command-line argument is missing"), usher(check_argument_missing)) &
         ,test_description_t(string_t("argument_present() result is .true. if a command-line argument is present"), usher(check_argument_present)) &
       ]
-    end if skip_all_tests_if_running_github_ci
+    end if
 
     end associate image_number
 


### PR DESCRIPTION
Closes some long-overdue gaps in our CI testing: ensuring we cover all the example code and run the command_line_t tests.

Also resolve #162 that has been responsible for false positives with ifx runtime failures on several occasions.